### PR TITLE
handle unavailable items in YouTube playlists

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/HollowYouTubeVideo.java
+++ b/src/main/java/net/robinfriedli/botify/audio/HollowYouTubeVideo.java
@@ -1,5 +1,6 @@
 package net.robinfriedli.botify.audio;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -21,8 +22,7 @@ public class HollowYouTubeVideo implements YouTubeVideo {
     private final CompletableFuture<Long> duration;
     @Nullable
     private final Track redirectedSpotifyTrack;
-    @Nullable
-    private YouTubePlaylist playlist;
+    private boolean canceled = false;
 
     public HollowYouTubeVideo(YouTubeService youTubeService) {
         this.youTubeService = youTubeService;
@@ -41,17 +41,17 @@ public class HollowYouTubeVideo implements YouTubeVideo {
     }
 
     @Override
-    public String getTitle() {
+    public String getTitle() throws InterruptedException {
         return getCompleted(title);
     }
 
     @Override
-    public String getId() {
+    public String getId() throws InterruptedException {
         return getCompleted(id);
     }
 
     @Override
-    public long getDuration() {
+    public long getDuration() throws InterruptedException {
         return getCompleted(duration);
     }
 
@@ -77,51 +77,30 @@ public class HollowYouTubeVideo implements YouTubeVideo {
         title.cancel(false);
         id.cancel(false);
         duration.cancel(false);
+        canceled = true;
     }
 
-    public boolean isComplete() {
-        return title.isDone() && id.isDone() && duration.isDone();
+    public boolean isCanceled() {
+        return canceled;
     }
 
-    public void setPlaylist(@Nullable YouTubePlaylist playlist) {
-        this.playlist = playlist;
+    public boolean isHollow() {
+        return !(title.isDone() || id.isDone() || duration.isDone());
     }
 
-    private <E> E getCompleted(CompletableFuture<E> future) {
-        if (future.isDone()) {
-            try {
-                return future.get();
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            completeManually();
-            try {
-                return future.get(3, TimeUnit.MINUTES);
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
-            } catch (TimeoutException e) {
-                throw new RuntimeException("Video loading timed out", e);
-            }
-        }
-    }
-
-    private void completeManually() {
-        // should be the CommandExceptionHandler of the current command
-        Thread.UncaughtExceptionHandler uncaughtExceptionHandler = Thread.currentThread().getUncaughtExceptionHandler();
-        Thread completionThread = new Thread(() -> {
-            if (redirectedSpotifyTrack != null) {
+    private <E> E getCompleted(CompletableFuture<E> future) throws InterruptedException {
+        try {
+            if (!future.isDone() && redirectedSpotifyTrack != null) {
                 youTubeService.redirectSpotify(this);
-            } else if (playlist != null) {
-                int i = playlist.getVideos().indexOf(this);
-                youTubeService.loadPlaylistItem(i, playlist);
             }
-        });
-        completionThread.setName("Botify manual HollowYouTubeVideo completion thread: " + toString());
-        if (uncaughtExceptionHandler != null) {
-            completionThread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
-        }
-        completionThread.start();
-    }
 
+            return future.get(3, TimeUnit.MINUTES);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Video loading timed out", e);
+        } catch (CancellationException e) {
+            throw new InterruptedException();
+        }
+    }
 }

--- a/src/main/java/net/robinfriedli/botify/audio/Playable.java
+++ b/src/main/java/net/robinfriedli/botify/audio/Playable.java
@@ -21,7 +21,7 @@ public class Playable {
         return delegate;
     }
 
-    public String getPlaybackUrl() {
+    public String getPlaybackUrl() throws InterruptedException {
         if (delegate() instanceof Track) {
             return ((Track) delegate()).getPreviewUrl();
         } else if (delegate() instanceof YouTubeVideo) {
@@ -31,7 +31,7 @@ public class Playable {
         }
     }
 
-    public String getDisplay() {
+    public String getDisplay() throws InterruptedException {
         if (delegate() instanceof Track) {
             Track track = (Track) delegate();
             String name = track.getName();
@@ -44,7 +44,7 @@ public class Playable {
         }
     }
 
-    public long getDurationMs() {
+    public long getDurationMs() throws InterruptedException {
         if (delegate() instanceof Track) {
             return ((Track) delegate()).getDurationMs();
         } else if (delegate() instanceof YouTubeVideo) {

--- a/src/main/java/net/robinfriedli/botify/audio/YouTubePlaylist.java
+++ b/src/main/java/net/robinfriedli/botify/audio/YouTubePlaylist.java
@@ -16,8 +16,6 @@ public class YouTubePlaylist {
         this.url = String.format("https://www.youtube.com/playlist?list=%s", id);
         this.channelTitle = channelTitle;
         this.videos = videos;
-
-        videos.forEach(video -> video.setPlaylist(this));
     }
 
     public String getTitle() {
@@ -41,7 +39,7 @@ public class YouTubePlaylist {
     }
 
     public void cancelLoading() {
-        videos.stream().filter(video -> !video.isComplete()).forEach(HollowYouTubeVideo::cancel);
+        videos.stream().filter(HollowYouTubeVideo::isHollow).forEach(HollowYouTubeVideo::cancel);
     }
 
 }

--- a/src/main/java/net/robinfriedli/botify/audio/YouTubeService.java
+++ b/src/main/java/net/robinfriedli/botify/audio/YouTubeService.java
@@ -286,6 +286,9 @@ public class YouTubeService {
             if (playlistItems.isEmpty()) {
                 throw new NoResultsFoundException("Playlist " + playlist.getTitle() + " has no items");
             }
+
+            // finally cancel each video that could be loaded e.g. if it's private
+            playlist.cancelLoading();
         } catch (IOException e) {
             throw new RuntimeException("Exception occurred while loading playlist items", e);
         }
@@ -293,14 +296,28 @@ public class YouTubeService {
 
     private void loadDurationsAsync(List<HollowYouTubeVideo> videos) {
         // ids have already been loaded in other thread
-        List<String> videoIds = videos.stream().map(HollowYouTubeVideo::getId).collect(Collectors.toList());
+        List<String> videoIds = Lists.newArrayList();
+        for (HollowYouTubeVideo hollowYouTubeVideo : videos) {
+            String id;
+            try {
+                id = hollowYouTubeVideo.getId();
+            } catch (InterruptedException e) {
+                return;
+            }
+            videoIds.add(id);
+        }
         // TrackLoadingExceptionHandler
         Thread.UncaughtExceptionHandler uncaughtExceptionHandler = Thread.currentThread().getUncaughtExceptionHandler();
         Thread durationLoadingThread = new Thread(() -> {
             try {
                 Map<String, Long> durationMillis = getDurationMillis(videoIds);
                 for (HollowYouTubeVideo video : videos) {
-                    Long duration = durationMillis.get(video.getId());
+                    Long duration;
+                    try {
+                        duration = durationMillis.get(video.getId());
+                    } catch (InterruptedException e) {
+                        return;
+                    }
                     video.setDuration(duration != null ? duration : 0);
                 }
             } catch (IOException e) {
@@ -320,7 +337,10 @@ public class YouTubeService {
      *
      * @param index the index of the item to load
      * @param playlist the playlist the item is a part of
+     * @deprecated deprecated as of 1.2.1 since the method is unreliable when the playlist contains unavailable items and
+     * very inefficient for minimal gain
      */
+    @Deprecated
     public void loadPlaylistItem(int index, YouTubePlaylist playlist) {
         if (index < 0 || index >= playlist.getVideos().size()) {
             throw new IllegalArgumentException("Index " + index + " out of bounds for list " + playlist.getTitle());

--- a/src/main/java/net/robinfriedli/botify/audio/YouTubeVideo.java
+++ b/src/main/java/net/robinfriedli/botify/audio/YouTubeVideo.java
@@ -12,21 +12,21 @@ public interface YouTubeVideo {
     /**
      * @return the title of the YouTube video
      */
-    String getTitle();
+    String getTitle() throws InterruptedException;
 
     /**
      * @return the id of the YouTube video
      */
-    String getId();
+    String getId() throws InterruptedException;
 
     /**
      * @return the duration of the YouTube video in milliseconds
      */
-    long getDuration();
+    long getDuration() throws InterruptedException;
 
     /**
      * @return if this YouTube video is the result of a redirected Spotify track, return the corresponding track,
-     * else return null. For more about Spotify track redirection, see {@link YouTubeService#redirectSpotify(Track)}
+     * else return null. For more about Spotify track redirection, see {@link YouTubeService#redirectSpotify(HollowYouTubeVideo)}
      */
     @Nullable
     Track getRedirectedSpotifyTrack();

--- a/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
@@ -25,7 +25,6 @@ import net.robinfriedli.botify.entities.Song;
 import net.robinfriedli.botify.entities.Video;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.botify.exceptions.NoResultsFoundException;
-import net.robinfriedli.botify.exceptions.TrackLoadingExceptionHandler;
 import net.robinfriedli.botify.util.SearchEngine;
 import net.robinfriedli.jxp.api.XmlElement;
 import net.robinfriedli.jxp.persist.Context;
@@ -140,14 +139,12 @@ public class AddCommand extends AbstractCommand {
     }
 
     private void addYouTubeList(YouTubePlaylist youTubePlaylist, Pair<String, String> pair, YouTubeService youTubeService) {
-        Thread loadingThread = new Thread(() -> youTubeService.populateList(youTubePlaylist));
-        TrackLoadingExceptionHandler eh = new TrackLoadingExceptionHandler(getManager().getLogger(), getContext().getChannel(), youTubePlaylist);
-        loadingThread.setUncaughtExceptionHandler(eh);
-        loadingThread.setName("Botify track loading thread " + youTubePlaylist.toString());
-        loadingThread.start();
+        youTubeService.populateList(youTubePlaylist);
         List<XmlElement> videos = Lists.newArrayList();
         for (HollowYouTubeVideo video : youTubePlaylist.getVideos()) {
-            videos.add(new Video(video, getContext().getUser(), getPersistContext()));
+            if (!video.isCanceled()) {
+                videos.add(new Video(video, getContext().getUser(), getPersistContext()));
+            }
         }
         addToList(pair.getRight(), videos);
     }
@@ -169,7 +166,14 @@ public class AddCommand extends AbstractCommand {
                 } else if (youTubeVideos.isEmpty()) {
                     throw new NoResultsFoundException("No YouTube videos found for " + pair.getRight());
                 } else {
-                    askQuestion(youTubeVideos, YouTubeVideo::getTitle);
+                    askQuestion(youTubeVideos, youTubeVideo -> {
+                        try {
+                            return youTubeVideo.getTitle();
+                        } catch (InterruptedException e) {
+                            // Unreachable since only HollowYouTubeVideos might get interrupted
+                            throw new RuntimeException(e);
+                        }
+                    });
                 }
             } else {
                 YouTubeVideo youTubeVideo = youTubeService.searchVideo(pair.getLeft());

--- a/src/main/java/net/robinfriedli/botify/command/commands/ExportCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/ExportCommand.java
@@ -7,6 +7,7 @@ import com.wrapper.spotify.model_objects.specification.Track;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.User;
 import net.robinfriedli.botify.audio.AudioQueue;
+import net.robinfriedli.botify.audio.HollowYouTubeVideo;
 import net.robinfriedli.botify.audio.Playable;
 import net.robinfriedli.botify.audio.YouTubeVideo;
 import net.robinfriedli.botify.command.AbstractCommand;
@@ -57,7 +58,9 @@ public class ExportCommand extends AbstractCommand {
                 playlistElems.add(new Song((Track) delegate, createUser, persistContext));
             } else if (delegate instanceof YouTubeVideo) {
                 YouTubeVideo youTubeVideo = (YouTubeVideo) delegate;
-                playlistElems.add(new Video(youTubeVideo, createUser, persistContext));
+                if (!(youTubeVideo instanceof HollowYouTubeVideo && ((HollowYouTubeVideo) youTubeVideo).isCanceled())) {
+                    playlistElems.add(new Video(youTubeVideo, createUser, persistContext));
+                }
             }
         }
 

--- a/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
@@ -113,7 +113,14 @@ public class PlayCommand extends AbstractCommand {
             } else if (youTubeVideos.isEmpty()) {
                 throw new NoResultsFoundException("No YouTube videos found for " + getCommandBody());
             } else {
-                askQuestion(youTubeVideos, YouTubeVideo::getTitle);
+                askQuestion(youTubeVideos, youTubeVideo -> {
+                    try {
+                        return youTubeVideo.getTitle();
+                    } catch (InterruptedException e) {
+                        // Unreachable since only HollowYouTubeVideos might get interrupted
+                        throw new RuntimeException(e);
+                    }
+                });
             }
         } else {
             YouTubeVideo youTubeVideo = youTubeService.searchVideo(getCommandBody());

--- a/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
@@ -78,7 +78,7 @@ public class SearchCommand extends AbstractCommand {
         }
     }
 
-    private void searchYouTubeVideo() {
+    private void searchYouTubeVideo() throws InterruptedException {
         YouTubeService youTubeService = getManager().getAudioManager().getYouTubeService();
         if (argumentSet("limit")) {
             int limit = getArgumentValue("limit", Integer.class);
@@ -92,14 +92,21 @@ public class SearchCommand extends AbstractCommand {
             } else if (youTubeVideos.isEmpty()) {
                 throw new NoResultsFoundException("No YouTube videos found for " + getCommandBody());
             } else {
-                askQuestion(youTubeVideos, YouTubeVideo::getTitle);
+                askQuestion(youTubeVideos, youTubeVideo -> {
+                    try {
+                        return youTubeVideo.getTitle();
+                    } catch (InterruptedException e) {
+                        // Unreachable since only HollowYouTubeVideos might get interrupted
+                        throw new RuntimeException(e);
+                    }
+                });
             }
         } else {
             listYouTubeVideo(youTubeService.searchVideo(getCommandBody()));
         }
     }
 
-    private void listYouTubeVideo(YouTubeVideo youTubeVideo) {
+    private void listYouTubeVideo(YouTubeVideo youTubeVideo) throws InterruptedException {
         StringBuilder responseBuilder = new StringBuilder();
         responseBuilder.append("Title: ").append(youTubeVideo.getTitle()).append(System.lineSeparator());
         responseBuilder.append("Id: ").append(youTubeVideo.getId()).append(System.lineSeparator());

--- a/src/main/java/net/robinfriedli/botify/discord/GuildSpecificationManager.java
+++ b/src/main/java/net/robinfriedli/botify/discord/GuildSpecificationManager.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Role;
@@ -85,6 +86,8 @@ public class GuildSpecificationManager {
         } else {
             GuildSpecification newSpecification = specificationContext.invoke(() -> {
                 GuildSpecification guildSpecification = new GuildSpecification(guild, specificationContext);
+                AccessConfiguration permissionConfiguration = new AccessConfiguration("permission", Lists.newArrayList(), specificationContext);
+                guildSpecification.addSubElement(permissionConfiguration);
                 guildSpecification.persist();
                 return guildSpecification;
             });

--- a/src/main/java/net/robinfriedli/botify/entities/Video.java
+++ b/src/main/java/net/robinfriedli/botify/entities/Video.java
@@ -46,18 +46,22 @@ public class Video extends AbstractXmlElement {
     }
 
     private static Map<String, ?> getAttributeMap(YouTubeVideo video, User addedUser) {
-        Track redirectedSpotifyTrack = video.getRedirectedSpotifyTrack();
-        Map<String, Object> attributeMap = new HashMap<>();
-        attributeMap.put("id", video.getId());
-        attributeMap.put("title", video.getTitle());
-        attributeMap.put("duration", video.getDuration());
-        attributeMap.put("addedUser", addedUser.getName());
-        attributeMap.put("addedUserId", addedUser.getId());
-        if (redirectedSpotifyTrack != null) {
-            attributeMap.put("redirectedSpotifyId", redirectedSpotifyTrack.getId());
-            attributeMap.put("spotifyTrackName", redirectedSpotifyTrack.getName());
-        }
+        try {
+            Track redirectedSpotifyTrack = video.getRedirectedSpotifyTrack();
+            Map<String, Object> attributeMap = new HashMap<>();
+            attributeMap.put("id", video.getId());
+            attributeMap.put("title", video.getTitle());
+            attributeMap.put("duration", video.getDuration());
+            attributeMap.put("addedUser", addedUser.getName());
+            attributeMap.put("addedUserId", addedUser.getId());
+            if (redirectedSpotifyTrack != null) {
+                attributeMap.put("redirectedSpotifyId", redirectedSpotifyTrack.getId());
+                attributeMap.put("spotifyTrackName", redirectedSpotifyTrack.getName());
+            }
 
-        return attributeMap;
+            return attributeMap;
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Cannot create video element for cancelled YouTube video " + video.toString());
+        }
     }
 }


### PR DESCRIPTION
 - cancel all videos that weren't completed by the
   YouTubeService#populateList method and make several YouTubeVideo
   methods throw an InterruptedException in case the video has been
   cancelled. Cancelled videos will be skipped when playing, ignored
   when adding to / creating local playlist and shown as "[UNAVAILABLE]"
   when displaying the current queue
 - deprecate YouTubeService#loadPlaylistItem as it is unreliable when
   there are unavailable videos in a playlist and barely made a
   difference because of its inefficiency
 - create access configuration for permission command when creating new
   guild specification