### PR TITLE
upgrade JXP to 1.0 and add playlist limits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>net.robinfriedli.JXP</groupId>
             <artifactId>JXP</artifactId>
-            <version>0.9</version>
+            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/resources/settings.properties
+++ b/resources/settings.properties
@@ -11,3 +11,5 @@ GUILD_SPECIFICATION_PATH=./resources/guildSpecifications.xml
 COMMANDS_PATH=./resources/commands.xml
 STARTUP_TASKS_PATH=./resources/startupTasks.xml
 MODE_PARTITIONED=true
+PLAYLIST_COUNT_MAX=50
+PLAYLIST_SIZE_MAX=5000

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/SetRedirectedSpotifyTrackNameTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/SetRedirectedSpotifyTrackNameTask.java
@@ -44,15 +44,15 @@ public class SetRedirectedSpotifyTrackNameTask implements StartupTask {
 
         for (File file : files) {
             if (file.exists()) {
-                Context context = jxpBackend.getContext(file);
-                context.invoke(() -> {
-                    try {
-                        migrate(context, spotifyApi);
-                    } catch (IOException | SpotifyWebApiException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-                jxpBackend.removeContext(file);
+                try (Context context = jxpBackend.getContext(file)) {
+                    context.invoke(() -> {
+                        try {
+                            migrate(context, spotifyApi);
+                        } catch (IOException | SpotifyWebApiException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
             }
         }
         spotifyApi.setAccessToken(null);

--- a/src/main/java/net/robinfriedli/botify/command/ArgumentContribution.java
+++ b/src/main/java/net/robinfriedli/botify/command/ArgumentContribution.java
@@ -172,7 +172,7 @@ public class ArgumentContribution {
             if (requiresValue && !hasValue()) {
                 throw new InvalidCommandException("Argument " + argument + " requires an assigned value!");
             } else if (!requiresValue && hasValue()) {
-                throw new InvalidCommandException("Argument " + argument + " does not require ans assigned value!");
+                throw new InvalidCommandException("Argument " + argument + " does not require an assigned value!");
             }
 
             if (requiresInput && getSourceCommand().getCommandBody().isBlank()) {

--- a/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
@@ -25,6 +25,7 @@ import net.robinfriedli.botify.entities.Song;
 import net.robinfriedli.botify.entities.Video;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.botify.exceptions.NoResultsFoundException;
+import net.robinfriedli.botify.util.PropertiesLoadingService;
 import net.robinfriedli.botify.util.SearchEngine;
 import net.robinfriedli.jxp.api.XmlElement;
 import net.robinfriedli.jxp.persist.Context;
@@ -213,6 +214,14 @@ public class AddCommand extends AbstractCommand {
 
         if (playlist == null) {
             throw new InvalidCommandException("No local list found for " + name);
+        }
+
+        String playlistSizeMax = PropertiesLoadingService.loadProperty("PLAYLIST_SIZE_MAX");
+        if (playlistSizeMax != null) {
+            int maxSize = Integer.parseInt(playlistSizeMax);
+            if (playlist.getAttribute("songCount").getInt() + elements.size() > maxSize) {
+                throw new InvalidCommandException("List exceeds maximum size of " + maxSize + " items!");
+            }
         }
 
         persistContext.invoke(true, true, () -> playlist.addSubElements(elements), getContext().getChannel());

--- a/src/main/java/net/robinfriedli/botify/command/commands/CreateCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/CreateCommand.java
@@ -6,6 +6,7 @@ import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
 import net.robinfriedli.botify.entities.Playlist;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
+import net.robinfriedli.botify.util.PropertiesLoadingService;
 import net.robinfriedli.jxp.api.XmlElement;
 import net.robinfriedli.jxp.persist.Context;
 
@@ -30,6 +31,14 @@ public class CreateCommand extends AbstractCommand {
 
         if (existingPlaylist != null) {
             throw new InvalidCommandException("Playlist " + getCommandBody() + " already exists");
+        }
+
+        String playlistCountMax = PropertiesLoadingService.loadProperty("PLAYLIST_COUNT_MAX");
+        if (playlistCountMax != null) {
+            int maxPlaylists = Integer.parseInt(playlistCountMax);
+            if (persistContext.getInstancesOf(Playlist.class).size() >= maxPlaylists) {
+                throw new InvalidCommandException("Maximum playlist count of " + maxPlaylists + " reached!");
+            }
         }
 
         Playlist playlist = new Playlist(getCommandBody(), getContext().getUser(), Lists.newArrayList(), persistContext);

--- a/src/main/java/net/robinfriedli/botify/command/commands/ExportCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/ExportCommand.java
@@ -17,6 +17,7 @@ import net.robinfriedli.botify.entities.Playlist;
 import net.robinfriedli.botify.entities.Song;
 import net.robinfriedli.botify.entities.Video;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
+import net.robinfriedli.botify.util.PropertiesLoadingService;
 import net.robinfriedli.jxp.api.XmlElement;
 import net.robinfriedli.jxp.persist.Context;
 
@@ -49,6 +50,22 @@ public class ExportCommand extends AbstractCommand {
         }
 
         List<Playable> tracks = queue.getTracks();
+
+        String playlistCountMax = PropertiesLoadingService.loadProperty("PLAYLIST_COUNT_MAX");
+        if (playlistCountMax != null) {
+            int maxPlaylists = Integer.parseInt(playlistCountMax);
+            if (persistContext.getInstancesOf(Playlist.class).size() >= maxPlaylists) {
+                throw new InvalidCommandException("Maximum playlist count of " + maxPlaylists + " reached!");
+            }
+        }
+        String playlistSizeMax = PropertiesLoadingService.loadProperty("PLAYLIST_SIZE_MAX");
+        if (playlistSizeMax != null) {
+            int maxSize = Integer.parseInt(playlistSizeMax);
+            if (tracks.size() > maxSize) {
+                throw new InvalidCommandException("List exceeds maximum size of " + maxSize + " items!");
+            }
+        }
+
         User createUser = getContext().getUser();
         List<XmlElement> playlistElems = Lists.newArrayList();
 

--- a/src/main/java/net/robinfriedli/botify/util/PropertiesLoadingService.java
+++ b/src/main/java/net/robinfriedli/botify/util/PropertiesLoadingService.java
@@ -4,6 +4,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Strings;
 
 public class PropertiesLoadingService {
@@ -18,14 +20,11 @@ public class PropertiesLoadingService {
     }
 
     public static String requireProperty(String key, String... args) {
-        String property = loadProperty(key, args);
-        if (!Strings.isNullOrEmpty(property)) {
-            return property;
-        } else {
-            throw new IllegalStateException("Property " + key + " not set");
-        }
+        String property = requireProperty(key);
+        return String.format(property, (Object[]) args);
     }
 
+    @Nullable
     public static String loadProperty(String key) {
         try {
             FileInputStream in = new FileInputStream("./resources/settings.properties");
@@ -34,19 +33,6 @@ public class PropertiesLoadingService {
             in.close();
 
             return properties.getProperty(key);
-        } catch (IOException e) {
-            throw new RuntimeException("Exception while loading property " + key, e);
-        }
-    }
-
-    public static String loadProperty(String key, String... args) {
-        try {
-            FileInputStream in = new FileInputStream("./resources/settings.properties");
-            Properties properties = new Properties();
-            properties.load(in);
-            in.close();
-
-            return String.format(properties.getProperty(key), (Object[]) args);
         } catch (IOException e) {
             throw new RuntimeException("Exception while loading property " + key, e);
         }


### PR DESCRIPTION
 - JXP was upgraded which fixes some issues that occurred when adding
   several items to a list concurrently, i.e. if the add command was
   used to add a large YouTube playlist to a local list several times in
   a short amount of time so that the first command had not been
   completed
 - there is now a limit as to how many playlists can be created and how
   many items one playlist can hold. Per default there can be
   50 playlists with 5000 items each. The limits can be removed by
   deleting the corresponding lines in the settings file