### PR TITLE
improve handling of track loading threads

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
@@ -15,7 +15,7 @@ public class AudioPlayback {
     private boolean repeatOne;
     private boolean repeatAll;
     // register Track loading Threads here so that they can be interrupted when a different playlist is being played
-    private Thread trackLoading;
+    private TrackLoadingThread trackLoading;
 
     public AudioPlayback(AudioPlayer player, Guild guild) {
         this.guild = guild;
@@ -91,14 +91,63 @@ public class AudioPlayback {
         audioQueue.setShuffle(isShuffle);
     }
 
-    public void registerTrackLoading(Thread trackLoading) {
-        interruptTrackLoading();
+    public void registerTrackLoading(TrackLoadingThread trackLoading) {
+        if (this.trackLoading != null) {
+            if (this.trackLoading.mayInterrupt()) {
+                interruptTrackLoading();
+            }
+        }
         this.trackLoading = trackLoading;
     }
 
     public void interruptTrackLoading() {
         if (trackLoading != null && trackLoading.isAlive()) {
             trackLoading.interrupt();
+        }
+    }
+
+    public void awaitLoaded() throws InterruptedException {
+        if (trackLoading != null) {
+            trackLoading.join();
+        } else {
+            System.out.println("bla");
+        }
+    }
+
+    public static class TrackLoadingThread {
+
+        private final Thread thread;
+        private final boolean mayInterrupt;
+
+        public TrackLoadingThread(Thread thread, boolean mayInterrupt) {
+            this.thread = thread;
+            this.mayInterrupt = mayInterrupt;
+        }
+
+        public void start() {
+            thread.start();
+        }
+
+        public boolean isAlive() {
+            return thread.isAlive();
+        }
+
+        public void interrupt() {
+            if (mayInterrupt) {
+                thread.interrupt();
+            }
+        }
+
+        public void join() throws InterruptedException {
+            thread.join();
+        }
+
+        public boolean mayInterrupt() {
+            return mayInterrupt;
+        }
+
+        public Thread getThread() {
+            return thread;
         }
     }
 


### PR DESCRIPTION
 - add flag to disable the interruption of a thread
   - used by add command where the playlist always have to be fully
     loaded no matter if something else is played afterwards
 - add method to await the track loading to finish
  - fixes an issue where when adding a youtube playlist via its URL and
    there were unavailable videos the video was not marked as cancelled
    when exporting and thus could not be ignored