### PR TITLE
handle insufficient permissions when sending messages

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/AudioManager.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioManager.java
@@ -32,6 +32,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 import com.wrapper.spotify.model_objects.specification.Track;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.VoiceChannel;
+import net.robinfriedli.botify.discord.AlertService;
 import net.robinfriedli.botify.entities.UrlTrack;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.botify.exceptions.NoResultsFoundException;
@@ -284,7 +285,9 @@ public class AudioManager extends AudioEventAdapter {
         if (playback.isShuffle()) {
             messageBuilder.append(" (shuffle)");
         }
-        playback.getCommunicationChannel().sendMessage(messageBuilder.toString()).queue();
+
+        AlertService alertService = new AlertService(logger);
+        alertService.send(messageBuilder.toString(), playback.getCommunicationChannel());
     }
 
     private void iterateQueue(AudioPlayback playback, AudioQueue audioQueue) {

--- a/src/main/java/net/robinfriedli/botify/boot/Launcher.java
+++ b/src/main/java/net/robinfriedli/botify/boot/Launcher.java
@@ -48,7 +48,7 @@ public class Launcher {
             boolean modePartitioned = PropertiesLoadingService.loadBoolProperty("MODE_PARTITIONED");
             // setup JXP
             JxpBackend jxpBackend = new JxpBuilder()
-                .addListeners(new AlertEventListener(), new PlaylistListener())
+                .addListeners(new AlertEventListener(logger), new PlaylistListener())
                 .mapClass("playlist", Playlist.class)
                 .mapClass("song", Song.class)
                 .mapClass("video", Video.class)

--- a/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
@@ -64,7 +64,7 @@ public abstract class AbstractCommand {
         this.description = description;
         this.category = category;
         this.argumentContribution = setupArguments();
-        this.alertService = new AlertService();
+        this.alertService = new AlertService(commandManager.getLogger());
 
         processCommand(commandString);
     }
@@ -207,7 +207,7 @@ public abstract class AbstractCommand {
     protected void askQuestion(ClientQuestionEvent question) {
         setFailed(true);
         commandManager.addQuestion(question);
-        question.ask();
+        question.ask(alertService);
     }
 
     protected void sendMessage(MessageChannel channel, String message) {
@@ -216,6 +216,10 @@ public abstract class AbstractCommand {
 
     protected void sendMessage(User user, String message) {
         alertService.send(message, user);
+    }
+
+    protected void sendWrapped(String message, String wrapper, MessageChannel channel) {
+        alertService.sendWrapped(message, wrapper, channel);
     }
 
     /**

--- a/src/main/java/net/robinfriedli/botify/command/ClientQuestionEvent.java
+++ b/src/main/java/net/robinfriedli/botify/command/ClientQuestionEvent.java
@@ -50,8 +50,7 @@ public class ClientQuestionEvent {
         return target.cast(get(key));
     }
 
-    public void ask() {
-        AlertService alertService = new AlertService();
+    public void ask(AlertService alertService) {
         StringBuilder questionBuilder = new StringBuilder();
         questionBuilder.append("Several options found: ").append(System.lineSeparator());
         questionBuilder.append("Choose an option using the answer command: $botify answer KEY");

--- a/src/main/java/net/robinfriedli/botify/command/CommandExecutor.java
+++ b/src/main/java/net/robinfriedli/botify/command/CommandExecutor.java
@@ -2,6 +2,8 @@ package net.robinfriedli.botify.command;
 
 import java.util.concurrent.Callable;
 
+import org.slf4j.Logger;
+
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.exceptions.detailed.UnauthorizedException;
 import com.wrapper.spotify.model_objects.credentials.ClientCredentials;
@@ -23,10 +25,12 @@ public class CommandExecutor {
 
     private final SpotifyApi spotifyApi;
     private final LoginManager loginManager;
+    private final Logger logger;
 
-    public CommandExecutor(SpotifyApi spotifyApi, LoginManager loginManager) {
+    public CommandExecutor(SpotifyApi spotifyApi, LoginManager loginManager, Logger logger) {
         this.spotifyApi = spotifyApi;
         this.loginManager = loginManager;
+        this.logger = logger;
     }
 
     public void runCommand(AbstractCommand command) {
@@ -45,15 +49,15 @@ public class CommandExecutor {
                 command.onSuccess();
             }
         } catch (NoLoginException e) {
-            AlertService alertService = new AlertService();
+            AlertService alertService = new AlertService(logger);
             MessageChannel channel = command.getContext().getChannel();
             User user = command.getContext().getUser();
             alertService.send("User " + user.getName() + " is not logged in to Spotify", channel);
         } catch (InvalidCommandException | NoResultsFoundException | ForbiddenCommandException e) {
-            AlertService alertService = new AlertService();
+            AlertService alertService = new AlertService(logger);
             alertService.send(e.getMessage(), command.getContext().getChannel());
         } catch (UnauthorizedException e) {
-            AlertService alertService = new AlertService();
+            AlertService alertService = new AlertService(logger);
             alertService.send("Unauthorized: " + e.getMessage(), command.getContext().getChannel());
         } catch (CommandRuntimeException e) {
             throw e;

--- a/src/main/java/net/robinfriedli/botify/command/commands/HelpCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/HelpCommand.java
@@ -26,7 +26,6 @@ public class HelpCommand extends AbstractCommand {
 
     @Override
     public void doRun() {
-        AlertService alertService = new AlertService();
         if (getCommandBody().isBlank()) {
             StringBuilder sb = new StringBuilder();
             sb.append("To get help with a specific command just enter the name of the command.").append(System.lineSeparator());
@@ -78,7 +77,7 @@ public class HelpCommand extends AbstractCommand {
                     sb.append(System.lineSeparator()).append(table.normalize());
                 }
 
-                alertService.sendWrapped(sb.toString(), "```", getContext().getChannel());
+                sendWrapped(sb.toString(), "```", getContext().getChannel());
             }, () -> {
                 throw new InvalidCommandException("No command found for " + getCommandBody());
             });

--- a/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
@@ -257,8 +257,7 @@ public class QueueCommand extends AbstractCommand {
             }
         }
 
-        AlertService alertService = new AlertService();
-        alertService.sendWrapped(responseBuilder.toString(), "```", getContext().getChannel());
+        sendWrapped(responseBuilder.toString(), "```", getContext().getChannel());
     }
 
     private void appendPlayable(Table table, Playable playable, boolean current) {

--- a/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
@@ -33,7 +33,6 @@ public class SearchCommand extends AbstractCommand {
 
     @Override
     public void doRun() throws Exception {
-        AlertService alertService = new AlertService();
         if (argumentSet("list")) {
             if (argumentSet("spotify")) {
                 listSpotifyList();
@@ -46,12 +45,12 @@ public class SearchCommand extends AbstractCommand {
             if (argumentSet("youtube")) {
                 searchYouTubeVideo();
             } else {
-                searchSpotifyTrack(alertService);
+                searchSpotifyTrack();
             }
         }
     }
 
-    private void searchSpotifyTrack(AlertService alertService) throws Exception {
+    private void searchSpotifyTrack() throws Exception {
         SpotifyApi spotifyApi = getManager().getSpotifyApi();
         List<Track> found;
         if (argumentSet("own")) {
@@ -71,7 +70,7 @@ public class SearchCommand extends AbstractCommand {
                 table.addRow(table.createCell(track.getName()), table.createCell(album), table.createCell(artist));
             }
 
-            alertService.sendWrapped(table.normalize(), "```", getContext().getChannel());
+            sendWrapped(table.normalize(), "```", getContext().getChannel());
         } else {
             sendMessage(getContext().getChannel(), "No results found");
         }
@@ -133,8 +132,7 @@ public class SearchCommand extends AbstractCommand {
                 table.addRow(table.createCell(name), table.createCell(duration, 10), table.createCell(items, 8));
             }
 
-            AlertService alertService = new AlertService();
-            alertService.sendWrapped(table.normalize(), "```", getContext().getChannel());
+            sendWrapped(table.normalize(), "```", getContext().getChannel());
         } else {
             Playlist playlist = SearchEngine.searchLocalList(getPersistContext(), getCommandBody());
             if (playlist == null) {
@@ -191,8 +189,7 @@ public class SearchCommand extends AbstractCommand {
                 responseBuilder.append(trackTable.normalize());
             }
 
-            AlertService alertService = new AlertService();
-            alertService.sendWrapped(responseBuilder.toString(), "```", getContext().getChannel());
+            sendWrapped(responseBuilder.toString(), "```", getContext().getChannel());
         }
     }
 
@@ -257,7 +254,6 @@ public class SearchCommand extends AbstractCommand {
     }
 
     private void listTracks(PlaylistSimplified playlist, List<Track> tracks) {
-        AlertService alertService = new AlertService();
         StringBuilder responseBuilder = new StringBuilder();
 
         Table overviewTable = Table.createNoBorder(50, 1, false);
@@ -290,7 +286,7 @@ public class SearchCommand extends AbstractCommand {
             responseBuilder.append(table.normalize());
         }
 
-        alertService.sendWrapped(responseBuilder.toString(), "```", getContext().getChannel());
+        sendWrapped(responseBuilder.toString(), "```", getContext().getChannel());
     }
 
     @Override

--- a/src/main/java/net/robinfriedli/botify/discord/GuildSpecificationManager.java
+++ b/src/main/java/net/robinfriedli/botify/discord/GuildSpecificationManager.java
@@ -12,6 +12,7 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.exceptions.InsufficientPermissionException;
 import net.robinfriedli.botify.entities.AccessConfiguration;
 import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.jxp.api.XmlElement;
@@ -99,13 +100,23 @@ public class GuildSpecificationManager {
     }
 
     private void alertNameChange(Guild guild) {
-        TextChannel defaultChannel = guild.getDefaultChannel();
-        if (defaultChannel != null) {
-            defaultChannel.sendMessage("Give me a name! Type \"$botify rename Your Name\"").queue();
-        } else {
-            TextChannel systemChannel = guild.getSystemChannel();
-            if (systemChannel != null) {
-                systemChannel.sendMessage("Give me a name! Type \"$botify rename Your Name\"").queue();
+        try {
+            TextChannel defaultChannel = guild.getDefaultChannel();
+            if (defaultChannel != null) {
+                defaultChannel.sendMessage("Give me a name! Type \"$botify rename Your Name\"").queue();
+            } else {
+                TextChannel systemChannel = guild.getSystemChannel();
+                if (systemChannel != null) {
+                    systemChannel.sendMessage("Give me a name! Type \"$botify rename Your Name\"").queue();
+                }
+            }
+        } catch (InsufficientPermissionException e) {
+            for (TextChannel textChannel : guild.getTextChannels()) {
+                try {
+                    textChannel.sendMessage("Give me a name! Type \"$botify rename Your Name\"").queue();
+                    break;
+                } catch (InsufficientPermissionException ignored){
+                }
             }
         }
     }

--- a/src/main/java/net/robinfriedli/botify/exceptions/CommandExceptionHandler.java
+++ b/src/main/java/net/robinfriedli/botify/exceptions/CommandExceptionHandler.java
@@ -21,7 +21,7 @@ public class CommandExceptionHandler implements Thread.UncaughtExceptionHandler 
         StringBuilder responseBuilder = new StringBuilder();
         MessageChannel channel = commandContext.getChannel();
         String command = commandContext.getMessage().getContentDisplay();
-        AlertService alertService = new AlertService();
+        AlertService alertService = new AlertService(logger);
 
         Throwable exception = e instanceof CommandRuntimeException ? e.getCause() : e;
         responseBuilder.append(String.format("Uncaught exception while handling command '%s'. Error (%s): %s",

--- a/src/main/java/net/robinfriedli/botify/exceptions/TrackLoadingExceptionHandler.java
+++ b/src/main/java/net/robinfriedli/botify/exceptions/TrackLoadingExceptionHandler.java
@@ -40,7 +40,7 @@ public class TrackLoadingExceptionHandler implements Thread.UncaughtExceptionHan
             logger.error("Exception while loading tracks", e);
         }
 
-        AlertService alertService = new AlertService();
+        AlertService alertService = new AlertService(logger);
         alertService.send(sb.toString(), channel);
     }
 


### PR DESCRIPTION
 - when the user would not give the bot enough permissions the
   exception thrown when sending a message would not get caught, which,
   for example, would cause the guild joining process to interrupt
   when the bot tries to send the name change notification