### PR TITLE
adjust source for YouTube videos and improve MessageService logging

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/youtube/HollowYouTubeVideo.java
+++ b/src/main/java/net/robinfriedli/botify/audio/youtube/HollowYouTubeVideo.java
@@ -56,8 +56,13 @@ public class HollowYouTubeVideo implements YouTubeVideo {
     }
 
     @Override
-    public String getId() throws InterruptedException {
+    public String getVideoId() throws InterruptedException {
         return getCompleted(id);
+    }
+
+    @Override
+    public String getId() throws InterruptedException {
+        return redirectedSpotifyTrack != null ? redirectedSpotifyTrack.getId() : getVideoId();
     }
 
     public void setId(String id) {
@@ -65,7 +70,7 @@ public class HollowYouTubeVideo implements YouTubeVideo {
     }
 
     @Override
-    public String getId(long timeOut, TimeUnit unit) throws InterruptedException, TimeoutException {
+    public String getVideoId(long timeOut, TimeUnit unit) throws InterruptedException, TimeoutException {
         return getWithTimeout(id, timeOut, unit);
     }
 
@@ -111,6 +116,11 @@ public class HollowYouTubeVideo implements YouTubeVideo {
 
     public boolean isHollow() {
         return !(title.isDone() || id.isDone() || duration.isDone());
+    }
+
+    @Override
+    public String getSource() {
+        return redirectedSpotifyTrack != null ? "Spotify" : "YouTube";
     }
 
     private <E> E getCompleted(CompletableFuture<E> future) throws InterruptedException {

--- a/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeService.java
+++ b/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeService.java
@@ -361,7 +361,7 @@ public class YouTubeService {
         for (HollowYouTubeVideo hollowYouTubeVideo : videos) {
             String id;
             try {
-                id = hollowYouTubeVideo.getId();
+                id = hollowYouTubeVideo.getVideoId();
             } catch (InterruptedException e) {
                 return;
             }
@@ -375,7 +375,7 @@ public class YouTubeService {
                 for (HollowYouTubeVideo video : videos) {
                     Long duration;
                     try {
-                        duration = durationMillis.get(video.getId());
+                        duration = durationMillis.get(video.getVideoId());
                     } catch (InterruptedException e) {
                         return;
                     }

--- a/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeVideo.java
+++ b/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeVideo.java
@@ -38,13 +38,18 @@ public interface YouTubeVideo extends Playable {
     /**
      * @return the id of the YouTube video
      */
-    String getId() throws InterruptedException;
+    String getVideoId() throws InterruptedException;
 
-    String getId(long timeOut, TimeUnit unit) throws InterruptedException, TimeoutException;
+    String getVideoId(long timeOut, TimeUnit unit) throws InterruptedException, TimeoutException;
+
+    @Override
+    default String getId() throws InterruptedException {
+        return getVideoId();
+    }
 
     @Override
     default String getPlaybackUrl() throws InterruptedException {
-        return String.format("https://www.youtube.com/watch?v=%s", getId());
+        return String.format("https://www.youtube.com/watch?v=%s", getVideoId());
     }
 
     /**

--- a/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeVideoImpl.java
+++ b/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeVideoImpl.java
@@ -32,13 +32,13 @@ public class YouTubeVideoImpl implements YouTubeVideo {
     }
 
     @Override
-    public String getId() {
+    public String getVideoId() {
         return id;
     }
 
     @Override
-    public String getId(long timeOut, TimeUnit unit) {
-        return getId();
+    public String getVideoId(long timeOut, TimeUnit unit) {
+        return getVideoId();
     }
 
     @Override

--- a/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
@@ -120,8 +120,8 @@ public class SearchCommand extends AbstractCommand {
     private void listYouTubeVideo(YouTubeVideo youTubeVideo) throws InterruptedException {
         StringBuilder responseBuilder = new StringBuilder();
         responseBuilder.append("Title: ").append(youTubeVideo.getTitle()).append(System.lineSeparator());
-        responseBuilder.append("Id: ").append(youTubeVideo.getId()).append(System.lineSeparator());
-        responseBuilder.append("Link: ").append("https://www.youtube.com/watch?v=").append(youTubeVideo.getId()).append(System.lineSeparator());
+        responseBuilder.append("Id: ").append(youTubeVideo.getVideoId()).append(System.lineSeparator());
+        responseBuilder.append("Link: ").append("https://www.youtube.com/watch?v=").append(youTubeVideo.getVideoId()).append(System.lineSeparator());
         responseBuilder.append("Duration: ").append(Util.normalizeMillis(youTubeVideo.getDuration()));
 
         sendMessage(responseBuilder.toString());

--- a/src/main/java/net/robinfriedli/botify/discord/MessageService.java
+++ b/src/main/java/net/robinfriedli/botify/discord/MessageService.java
@@ -247,7 +247,14 @@ public class MessageService {
                     futureMessage.completeExceptionally(e);
                 }
             } else {
-                logger.warn("Bot is missing unexpected permission " + permission, e);
+                String message = "Bot is missing permission " + permission.getName();
+                sendError(message, channel);
+
+                StringBuilder errorMessage = new StringBuilder("Missing permission ").append(permission);
+                if (channel instanceof TextChannel) {
+                    errorMessage.append(" on guild ").append(((TextChannel) channel).getGuild());
+                }
+                logger.warn(errorMessage.toString());
                 futureMessage.completeExceptionally(e);
             }
         }

--- a/src/main/java/net/robinfriedli/botify/entities/Video.java
+++ b/src/main/java/net/robinfriedli/botify/entities/Video.java
@@ -35,7 +35,7 @@ public class Video extends PlaylistItem {
     public Video(YouTubeVideo video, User user, Playlist playlist) {
         super(user, playlist);
         try {
-            id = video.getId();
+            id = video.getVideoId();
             title = video.getTitle();
             duration = video.getDuration();
 


### PR DESCRIPTION
 - return "Spotify" as source and the Spotify track id for
   HollowYouTubeVideos that were originally redirected Spotify tracks
 - make missing permission exceptions when sending a message take up
   less space in the logs and send a warning to the user
   - often occurs when the user did not grant the bot permission to
     embed links or attach files