### PR TITLE
add property to set default source for commands that search a track

### DIFF
--- a/resources/xml-contributions/commands.xml
+++ b/resources/xml-contributions/commands.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <commands xmlns="commandSpace">
   <command identifier="add" implementation="net.robinfriedli.botify.command.commands.AddCommand"
-           description="Add a specific song from spotify, youtube, the current queue or any URL to the specified local playlist. Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters). To add tracks to the queue see the queue command.">
+           description="Add a specific song from spotify, youtube, the current queue or any URL to the specified local playlist. Which source is used is decided by the used arguments or the default source and default list source properties. Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters). To add tracks to the queue see the queue command.">
     <example title="Add a specific track">$botify add $spotify $own from the inside $to my list.</example>
     <example title="Add tracks from the current queue to a list">$botify add $queue my list</example>
     <example title="Add tracks from a url">$botify add http://someurl.com $to linkin park</example>
@@ -31,7 +31,7 @@
     <example title="Login to Spotify.">$botify login</example>
   </command>
   <command identifier="play" implementation="net.robinfriedli.botify.command.commands.PlayCommand"
-           description="Resume the paused playback, play the current track in the queue or play the specified track, video or playlist. Can play any URL or search youtube and spotify tracks or lists and also local playlists. Local playlists, like the queue, can contain tracks from any source (YouTube, Spotify and URL). Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters).">
+           description="Resume the paused playback, play the current track in the queue or play the specified track, video or playlist. Can play any URL or search youtube and spotify tracks or lists and also local playlists. Local playlists, like the queue, can contain tracks from any source (YouTube, Spotify and URL). Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters). Which source is used is decided by the used arguments or the default source and default list source properties.">
     <example title="Play the current queue or unpause playback">$botify play</example>
     <example title="Play a specific track from Spotify">$botify play numb</example>
     <example title="Play a track from a specific artist and album">$botify play from the inside artist:linkin park album:meteora</example>
@@ -45,7 +45,7 @@
   <command identifier="pause" implementation="net.robinfriedli.botify.command.commands.PauseCommand"
            description="Pause the current playback."/>
   <command identifier="queue" implementation="net.robinfriedli.botify.command.commands.QueueCommand"
-           description="Display the current queue or add a youtube video or playlist, spotify track or playlist, local playlist or any URL to the current queue. Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters).">
+           description="Display the current queue or add a youtube video or playlist, spotify track or playlist, local playlist or any URL to the current queue. Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters). Which source is used is decided by the used arguments or the default source and default list source properties.">
     <example title="Display the queue widget">$botify queue</example>
     <example title="Add a specific track from Spotify to the queue">$botify queue numb</example>
     <example title="Add a track from a specific artist and album">$botify queue from the inside artist:linkin park album:meteora</example>
@@ -77,7 +77,7 @@
     <example title="Rewind 6 tracks">$botify rewind 6</example>
   </command>
   <command identifier="search" implementation="net.robinfriedli.botify.command.commands.SearchCommand"
-           description="Search for YouTube and Spotify tracks or playlists and local playlists or list all local playlists. Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters).">
+           description="Search for YouTube and Spotify tracks or playlists and local playlists or list all local playlists. Spotify search queries support the Spotify query syntax (i.e. the &quot;artist:&quot;, &quot;album:&quot; and &quot;track:&quot; filters). Which source is used is decided by the used arguments or the default source and default list source properties.">
     <example title="List all local playlists">$botify search $list</example>
     <example title="Search for a specific local list">$botify search $list my list</example>
     <example title="Search for a Spotify track">$botify search $spotify numb artist:linkin park album:meteora</example>
@@ -156,6 +156,8 @@
     <example title="set the color of botify messages to blue">$botify property color $set blue</example>
     <example title="set the color to Spotify green">$botify property color $set #1DB954</example>
     <example title="toggle playback notifications">$botify property $toggle playback notification</example>
+    <example title="set the default service when searching for a track">$botify property default source $set youtube</example>
+    <example title="set the default service when searching for a list">$botify property default list source $set local</example>
   </command>
 
   <!-- Administrator commands -->

--- a/resources/xml-contributions/guildProperties.xml
+++ b/resources/xml-contributions/guildProperties.xml
@@ -5,4 +5,6 @@
   <guildProperty property="sendPlaybackNotification" name="playback notification" defaultValue="true" implementation="net.robinfriedli.botify.discord.properties.PlaybackNotificationProperty" updateMessage="Set playback notification to %s"/>
   <guildProperty property="color" name="color" defaultValue="#1DB954" implementation="net.robinfriedli.botify.discord.properties.ColorSchemeProperty" updateMessage="Changed colour to %s"/>
   <guildProperty property="enableAutoPause" name="auto pause" defaultValue="true" implementation="net.robinfriedli.botify.discord.properties.AutoPauseProperty" updateMessage="Set auto pause to %s"/>
+  <guildProperty property="defaultSource" name="default source" defaultValue="SPOTIFY" implementation="net.robinfriedli.botify.discord.properties.DefaultSourceProperty" updateMessage="Set the default search source to %s"/>
+  <guildProperty property="defaultListSource" name="default list source" defaultValue="LOCAL" implementation="net.robinfriedli.botify.discord.properties.DefaultListSourceProperty" updateMessage="Set the default list search source to %s"/>
 </guildProperties>

--- a/src/main/java/net/robinfriedli/botify/command/commands/AbstractQueueLoadingCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AbstractQueueLoadingCommand.java
@@ -20,7 +20,6 @@ import net.robinfriedli.botify.audio.spotify.SpotifyUri;
 import net.robinfriedli.botify.audio.youtube.YouTubePlaylist;
 import net.robinfriedli.botify.audio.youtube.YouTubeService;
 import net.robinfriedli.botify.audio.youtube.YouTubeVideo;
-import net.robinfriedli.botify.command.AbstractCommand;
 import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
 import net.robinfriedli.botify.entities.Playlist;
@@ -31,7 +30,7 @@ import net.robinfriedli.botify.exceptions.NoSpotifyResultsFoundException;
 import net.robinfriedli.botify.util.SearchEngine;
 import net.robinfriedli.stringlist.StringListImpl;
 
-public abstract class AbstractQueueLoadingCommand extends AbstractCommand {
+public abstract class AbstractQueueLoadingCommand extends AbstractSourceDecidingCommand {
 
     private final boolean mayInterrupt;
     int loadedAmount;
@@ -65,20 +64,20 @@ public abstract class AbstractQueueLoadingCommand extends AbstractCommand {
         } else if (SpotifyUri.isSpotifyUri(getCommandBody())) {
             loadSpotifyUri(audioManager);
         } else if (argumentSet("list")) {
-            if (argumentSet("spotify")) {
+            Source source = getSource();
+            if (source.isSpotify()) {
                 loadSpotifyList(audioManager);
-            } else if (argumentSet("youtube")) {
+            } else if (source.isYouTube()) {
                 loadYouTubeList(audioManager);
             } else {
                 loadLocalList(audioManager);
             }
         } else {
-            if (argumentSet("youtube")) {
+            Source source = getSource();
+            if (source.isYouTube()) {
                 loadYouTubeVideo(audioManager);
             } else if (argumentSet("album")) {
                 loadSpotifyAlbum(audioManager);
-            } else if (UrlValidator.getInstance().isValid(getCommandBody())) {
-                loadUrlItems(audioManager, playback);
             } else {
                 loadTrack(audioManager);
             }

--- a/src/main/java/net/robinfriedli/botify/command/commands/AbstractSourceDecidingCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AbstractSourceDecidingCommand.java
@@ -1,0 +1,92 @@
+package net.robinfriedli.botify.command.commands;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import net.robinfriedli.botify.Botify;
+import net.robinfriedli.botify.command.AbstractCommand;
+import net.robinfriedli.botify.command.CommandContext;
+import net.robinfriedli.botify.command.CommandManager;
+import net.robinfriedli.botify.discord.properties.AbstractGuildProperty;
+import net.robinfriedli.botify.discord.properties.GuildPropertyManager;
+import net.robinfriedli.botify.entities.xml.CommandContribution;
+
+/**
+ * Extension for commands that can search both YouTube and Spotify (e.g. the play, queue, add and search commands)
+ * that returns the selected source based on the used arguments and the defaultSource property.
+ */
+public abstract class AbstractSourceDecidingCommand extends AbstractCommand {
+
+    private static final Source DEFAULT_FALLBACK = Source.SPOTIFY;
+    private static final Source DEFAULT_LIST_FALLBACK = Source.LOCAL;
+
+    protected AbstractSourceDecidingCommand(CommandContribution commandContribution, CommandContext context, CommandManager commandManager, String commandString, boolean requiresInput, String identifier, String description, Category category) {
+        super(commandContribution, context, commandManager, commandString, requiresInput, identifier, description, category);
+    }
+
+    protected Source getSource() {
+        if (argumentSet("spotify")) {
+            return Source.SPOTIFY;
+        } else if (argumentSet("youtube")) {
+            return Source.YOUTUBE;
+        } else if (argumentSet("local")) {
+            return Source.LOCAL;
+        } else {
+            return getDefaultSource();
+        }
+    }
+
+    private Source getDefaultSource() {
+        GuildPropertyManager guildPropertyManager = Botify.get().getGuildPropertyManager();
+        if (argumentSet("list")) {
+            AbstractGuildProperty defaultListSourceProperty = guildPropertyManager.getProperty("defaultListSource");
+            if (defaultListSourceProperty != null) {
+                return getSourceForProperty(defaultListSourceProperty).orElse(DEFAULT_LIST_FALLBACK);
+            }
+
+            return DEFAULT_LIST_FALLBACK;
+        } else {
+            AbstractGuildProperty defaultSourceProperty = guildPropertyManager.getProperty("defaultSource");
+            if (defaultSourceProperty != null) {
+                return getSourceForProperty(defaultSourceProperty).orElse(DEFAULT_FALLBACK);
+            }
+
+            return DEFAULT_FALLBACK;
+        }
+    }
+
+    private Optional<Source> getSourceForProperty(AbstractGuildProperty property) {
+        return Arrays.stream(Source.values())
+            .filter(source -> source.name().equals(property.get())).findAny();
+    }
+
+    protected enum Source {
+
+        SPOTIFY(true, false, false),
+        YOUTUBE(false, true, false),
+        LOCAL(false, false, true);
+
+        private final boolean isSpotify;
+        private final boolean isYouTube;
+        private final boolean isLocal;
+
+        Source(boolean isSpotify, boolean isYouTube, boolean isLocal) {
+            this.isSpotify = isSpotify;
+            this.isYouTube = isYouTube;
+            this.isLocal = isLocal;
+        }
+
+        public boolean isSpotify() {
+            return isSpotify;
+        }
+
+        public boolean isYouTube() {
+            return isYouTube;
+        }
+
+        public boolean isLocal() {
+            return isLocal;
+        }
+    }
+
+}

--- a/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
@@ -24,7 +24,6 @@ import net.robinfriedli.botify.audio.youtube.HollowYouTubeVideo;
 import net.robinfriedli.botify.audio.youtube.YouTubePlaylist;
 import net.robinfriedli.botify.audio.youtube.YouTubeService;
 import net.robinfriedli.botify.audio.youtube.YouTubeVideo;
-import net.robinfriedli.botify.command.AbstractCommand;
 import net.robinfriedli.botify.command.ArgumentContribution;
 import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
@@ -41,7 +40,7 @@ import net.robinfriedli.botify.util.SearchEngine;
 import net.robinfriedli.stringlist.StringListImpl;
 import org.hibernate.Session;
 
-public class AddCommand extends AbstractCommand {
+public class AddCommand extends AbstractSourceDecidingCommand {
 
     public AddCommand(CommandContribution commandContribution, CommandContext context, CommandManager commandManager, String commandString, String identifier, String description) {
         super(commandContribution, context, commandManager, commandString, true, identifier, description, Category.PLAYLIST_MANAGEMENT);
@@ -134,9 +133,10 @@ public class AddCommand extends AbstractCommand {
     }
 
     private void addList(Playlist playlist, String searchTerm) throws Exception {
-        if (argumentSet("spotify")) {
+        Source source = getSource();
+        if (source.isSpotify()) {
             addSpotifyList(playlist, searchTerm);
-        } else if (argumentSet("youtube")) {
+        } else if (source.isYouTube()) {
             addYouTubeList(playlist, searchTerm);
         } else {
             addLocalList(playlist, searchTerm);
@@ -252,7 +252,8 @@ public class AddCommand extends AbstractCommand {
     }
 
     private void addSpecificTrack(Playlist playlist, String searchTerm) throws Exception {
-        if (argumentSet("youtube")) {
+        Source source = getSource();
+        if (source.isYouTube()) {
             YouTubeService youTubeService = Botify.get().getAudioManager().getYouTubeService();
             if (argumentSet("limit")) {
                 int limit = getArgumentValue("limit", Integer.class);
@@ -358,7 +359,7 @@ public class AddCommand extends AbstractCommand {
             .setDescription("Limit search to tracks in your library. This requires a Spotify login.");
         argumentContribution.map("list")
             .setDescription("Add tracks from a Spotify, YouTube or local list to a list.");
-        argumentContribution.map("local").needsArguments("list")
+        argumentContribution.map("local").needsArguments("list").excludesArguments("youtube", "spotify")
             .setDescription("Add items from a local list. This is the default option when adding lists.");
         argumentContribution.map("limit").needsArguments("youtube").setRequiresValue(true)
             .setDescription("Show a selection of youtube playlists or videos to chose from. Requires value from 1 to 10: $limit=5");

--- a/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
@@ -108,7 +108,7 @@ public class PlayCommand extends AbstractQueueLoadingCommand {
             .setDescription("Play a YouTube video or playlist. Note that this argument is only required when searching, not when entering a URL.");
         argumentContribution.map("own").needsArguments("spotify")
             .setDescription("Limit search to Spotify tracks or lists that are in the current user's library. This requires a Spotify login.");
-        argumentContribution.map("local").needsArguments("list")
+        argumentContribution.map("local").needsArguments("list").excludesArguments("spotify", "youtube")
             .setDescription("Play a local list.");
         argumentContribution.map("limit").needsArguments("youtube").setRequiresValue(true)
             .setDescription("Show a selection of YouTube playlists or videos to chose from. Requires value from 1 to 10: $limit=5");

--- a/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
@@ -115,12 +115,12 @@ public class QueueCommand extends AbstractQueueLoadingCommand {
         argumentContribution.map("youtube").setRequiresInput(true).excludesArguments("preview")
             .setDescription("Queue a YouTube video. Note that this argument is only required when searching, not when entering a URL.");
         argumentContribution.map("list").setRequiresInput(true)
-            .setDescription("Add the elements from a Spotify, YouTube or local Playlist to the current queue (local is default).");
+            .setDescription("Add the elements from a Spotify, YouTube or local Playlist to the current queue. Adds items from the default list source according to the set property if none of those 3 are set.");
         argumentContribution.map("spotify").setRequiresInput(true).excludesArguments("youtube")
             .setDescription("Queue Spotify track, playlist or album. This supports Spotify query syntax (i.e. the filters \"artist:\", \"album:\", etc.). Note that this argument is only required when searching, not when entering a URL.");
         argumentContribution.map("own").needsArguments("spotify")
             .setDescription("Limit search to Spotify tracks and playlists in the current users library. This requires a Spotify login.");
-        argumentContribution.map("local").needsArguments("list")
+        argumentContribution.map("local").needsArguments("list").excludesArguments("spotify", "youtube")
             .setDescription("Queue local playlist.");
         argumentContribution.map("limit").needsArguments("youtube").setRequiresValue(true)
             .setDescription("Show a selection of YouTube playlists or videos to chose from. Requires value from 1 to 10: $limit=5");

--- a/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
@@ -16,7 +16,6 @@ import net.robinfriedli.botify.Botify;
 import net.robinfriedli.botify.audio.youtube.YouTubePlaylist;
 import net.robinfriedli.botify.audio.youtube.YouTubeService;
 import net.robinfriedli.botify.audio.youtube.YouTubeVideo;
-import net.robinfriedli.botify.command.AbstractCommand;
 import net.robinfriedli.botify.command.ArgumentContribution;
 import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
@@ -33,7 +32,7 @@ import net.robinfriedli.botify.util.Util;
 import net.robinfriedli.stringlist.StringListImpl;
 import org.hibernate.Session;
 
-public class SearchCommand extends AbstractCommand {
+public class SearchCommand extends AbstractSourceDecidingCommand {
 
     public SearchCommand(CommandContribution commandContribution, CommandContext commandContext, CommandManager commandManager, String commandString, String identifier, String description) {
         super(commandContribution, commandContext, commandManager, commandString, false, identifier, description, Category.SEARCH);
@@ -41,10 +40,11 @@ public class SearchCommand extends AbstractCommand {
 
     @Override
     public void doRun() throws Exception {
+        Source source = getSource();
         if (argumentSet("list")) {
-            if (argumentSet("spotify")) {
+            if (source.isSpotify()) {
                 listSpotifyList();
-            } else if (argumentSet("youtube")) {
+            } else if (source.isYouTube()) {
                 listYouTubePlaylists();
             } else {
                 listLocalList();
@@ -52,7 +52,7 @@ public class SearchCommand extends AbstractCommand {
         } else if (argumentSet("album")) {
             listSpotifyAlbum();
         } else {
-            if (argumentSet("youtube")) {
+            if (source.isYouTube()) {
                 searchYouTubeVideo();
             } else {
                 searchSpotifyTrack();
@@ -341,7 +341,7 @@ public class SearchCommand extends AbstractCommand {
             .setDescription("Search for YouTube video or playlist.");
         argumentContribution.map("list")
             .setDescription("Search for a playlist.");
-        argumentContribution.map("local").needsArguments("list")
+        argumentContribution.map("local").needsArguments("list").excludesArguments("youtube", "spotify")
             .setDescription("Search for a local playlist or list all of them. This is default when searching for lists.");
         argumentContribution.map("own").needsArguments("spotify")
             .setDescription("Limit search to Spotify tracks or playlists in the current user's library. This requires a Spotify login.");

--- a/src/main/java/net/robinfriedli/botify/discord/properties/DefaultListSourceProperty.java
+++ b/src/main/java/net/robinfriedli/botify/discord/properties/DefaultListSourceProperty.java
@@ -1,0 +1,38 @@
+package net.robinfriedli.botify.discord.properties;
+
+import net.robinfriedli.botify.entities.GuildSpecification;
+import net.robinfriedli.botify.entities.xml.GuildPropertyContribution;
+import net.robinfriedli.botify.exceptions.InvalidPropertyValueException;
+
+public class DefaultListSourceProperty extends AbstractGuildProperty {
+
+    public DefaultListSourceProperty(GuildPropertyContribution contribution) {
+        super(contribution);
+    }
+
+    @Override
+    public void validate(Object state) {
+        String input = (String) state;
+        if (!(input.equalsIgnoreCase("spotify")
+            || input.equalsIgnoreCase("youtube")
+            || input.equalsIgnoreCase("local"))) {
+            throw new InvalidPropertyValueException("Source needs to be either 'spotify', 'youtube' or 'local'");
+        }
+    }
+
+    @Override
+    public Object process(String input) {
+        return input;
+    }
+
+    @Override
+    public void setValue(String value, GuildSpecification guildSpecification) {
+        guildSpecification.setDefaultListSource(value.toUpperCase());
+    }
+
+    @Override
+    public Object extractPersistedValue(GuildSpecification guildSpecification) {
+        return guildSpecification.getDefaultListSource();
+    }
+
+}

--- a/src/main/java/net/robinfriedli/botify/discord/properties/DefaultSourceProperty.java
+++ b/src/main/java/net/robinfriedli/botify/discord/properties/DefaultSourceProperty.java
@@ -1,0 +1,35 @@
+package net.robinfriedli.botify.discord.properties;
+
+import net.robinfriedli.botify.entities.GuildSpecification;
+import net.robinfriedli.botify.entities.xml.GuildPropertyContribution;
+import net.robinfriedli.botify.exceptions.InvalidPropertyValueException;
+
+public class DefaultSourceProperty extends AbstractGuildProperty {
+
+    public DefaultSourceProperty(GuildPropertyContribution contribution) {
+        super(contribution);
+    }
+
+    @Override
+    public void validate(Object state) {
+        String input = (String) state;
+        if (!(input.equalsIgnoreCase("spotify") || input.equalsIgnoreCase("youtube"))) {
+            throw new InvalidPropertyValueException("Source needs to be either 'spotify' or 'youtube'");
+        }
+    }
+
+    @Override
+    public Object process(String input) {
+        return input;
+    }
+
+    @Override
+    public void setValue(String value, GuildSpecification guildSpecification) {
+        guildSpecification.setDefaultSource(value.toUpperCase());
+    }
+
+    @Override
+    public Object extractPersistedValue(GuildSpecification guildSpecification) {
+        return guildSpecification.getDefaultSource();
+    }
+}

--- a/src/main/java/net/robinfriedli/botify/entities/GuildSpecification.java
+++ b/src/main/java/net/robinfriedli/botify/entities/GuildSpecification.java
@@ -40,6 +40,10 @@ public class GuildSpecification implements Serializable {
     private String color;
     @Column(name = "enable_auto_pause")
     private Boolean enableAutoPause;
+    @Column(name = "default_source")
+    private String defaultSource;
+    @Column(name = "default_list_source")
+    private String defaultListSource;
     @OneToMany(mappedBy = "guildSpecification", fetch = FetchType.EAGER)
     private Set<AccessConfiguration> accessConfigurations = Sets.newHashSet();
 
@@ -138,5 +142,21 @@ public class GuildSpecification implements Serializable {
 
     public void setColor(String color) {
         this.color = color;
+    }
+
+    public String getDefaultSource() {
+        return defaultSource;
+    }
+
+    public void setDefaultSource(String defaultSource) {
+        this.defaultSource = defaultSource;
+    }
+
+    public String getDefaultListSource() {
+        return defaultListSource;
+    }
+
+    public void setDefaultListSource(String defaultListSource) {
+        this.defaultListSource = defaultListSource;
     }
 }

--- a/src/main/java/net/robinfriedli/botify/entities/xml/GuildPropertyContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/GuildPropertyContribution.java
@@ -26,7 +26,7 @@ public class GuildPropertyContribution extends GenericClassContribution<Abstract
     @Nullable
     @Override
     public String getId() {
-        return getName();
+        return getProperty();
     }
 
     public String getProperty() {

--- a/src/main/java/net/robinfriedli/botify/exceptions/NoSpotifyResultsFoundException.java
+++ b/src/main/java/net/robinfriedli/botify/exceptions/NoSpotifyResultsFoundException.java
@@ -22,7 +22,8 @@ public class NoSpotifyResultsFoundException extends NoResultsFoundException {
         return (message.length() > 1000 ? message.substring(0, 1000) + "..." : message) + System.lineSeparator() + System.lineSeparator() +
             "_Mind that Spotify queries, unlike YouTube, are not a fulltext search so you shouldn't type 'numb by linkin park' " +
             "but rather use the appropriate filters; e.g. 'numb artist:linkin park'. If you didn't actually mean to search " +
-            "for a Spotify track but rather a playlist or YouTube video, see 'help play' to find the needed arguments._";
+            "for a Spotify track but rather a playlist or YouTube video, see 'help play' to find the needed arguments or " +
+            "adjust the default source using the property command._";
     }
 
 }


### PR DESCRIPTION
 - allows to set youtube or spotify as the default source for tracks and
   youtube, spotify or local as default source for searching lists
   - this applies to the play, queue, add, insert and search commands
 - add "spotify" and "youtube" as excluded arguments for the "local"
   argument as they cannot be used together