### PR TITLE
hibernate optimisations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
       <version>5.4.2.Final</version>
     </dependency>
     <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>3.8.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>5.4.2.Final</version>
@@ -111,6 +116,11 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-c3p0</artifactId>
+      <version>5.4.2.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-jcache</artifactId>
       <version>5.4.2.Final</version>
     </dependency>
     <dependency>

--- a/resources/hibernate.cfg.xml
+++ b/resources/hibernate.cfg.xml
@@ -18,6 +18,12 @@
     <property name="hibernate.c3p0.max_size">20</property>
     <property name="hibernate.c3p0.timeout">1800</property>
     <property name="hibernate.c3p0.max_statements">50</property>
+    <!-- ehcache -->
+    <property name="hibernate.cache.use_query_cache">true</property>
+    <property name="hibernate.cache.use_second_level_cache">true</property>
+    <property name="hibernate.cache.region.factory_class">org.hibernate.cache.jcache.JCacheRegionFactory</property>
+    <property name="hibernate.javax.cache.provider">org.ehcache.jsr107.EhcacheCachingProvider</property>
+    <property name="hibernate.javax.cache.missing_cache_strategy">create</property>
     <!-- annotated classes -->
     <mapping class="net.robinfriedli.botify.entities.Playlist"/>
     <mapping class="net.robinfriedli.botify.entities.Song"/>

--- a/src/main/java/net/robinfriedli/botify/audio/AudioQueue.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioQueue.java
@@ -1,5 +1,6 @@
 package net.robinfriedli.botify.audio;
 
+import java.awt.Color;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -10,11 +11,12 @@ import com.google.common.collect.Lists;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.entities.Guild;
 import net.robinfriedli.botify.Botify;
-import net.robinfriedli.botify.discord.GuildContext;
 import net.robinfriedli.botify.discord.properties.ColorSchemeProperty;
+import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.exceptions.NoResultsFoundException;
 import net.robinfriedli.botify.util.EmojiConstants;
 import net.robinfriedli.botify.util.PropertiesLoadingService;
+import net.robinfriedli.botify.util.StaticSessionProvider;
 import net.robinfriedli.botify.util.Util;
 
 public class AudioQueue {
@@ -163,8 +165,11 @@ public class AudioQueue {
             }
         }
 
-        GuildContext guildContext = Botify.get().getGuildManager().getContextForGuild(guild);
-        embedBuilder.setColor(ColorSchemeProperty.getColor(guildContext));
+        Color color = StaticSessionProvider.invokeWithSession(session -> {
+            GuildSpecification specification = Botify.get().getGuildManager().getContextForGuild(guild).getSpecification(session);
+            return ColorSchemeProperty.getColor(specification);
+        });
+        embedBuilder.setColor(color);
         return embedBuilder;
     }
 

--- a/src/main/java/net/robinfriedli/botify/boot/Launcher.java
+++ b/src/main/java/net/robinfriedli/botify/boot/Launcher.java
@@ -57,6 +57,8 @@ public class Launcher {
     public static void main(String[] args) {
         // setup logger
         System.setProperty("log4j.configurationFile", "./resources/log4j2.properties");
+        // setup ehcache configuration
+        System.setProperty("net.sf.ehcache.configurationResourceName", "ehcache.xml");
         Logger logger = LoggerFactory.getLogger(Launcher.class);
         try {
             // initialize property values
@@ -129,7 +131,7 @@ public class Launcher {
             Context commandInterceptorContext = jxpBackend.getContext(PropertiesLoadingService.requireProperty("COMMAND_INTERCEPTORS_PATH"));
             Context guildPropertyContext = jxpBackend.getContext(PropertiesLoadingService.requireProperty("GUILD_PROPERTIES_PATH"));
 
-            CommandManager commandManager = new CommandManager(commandContributionContext, commandInterceptorContext, sessionFactory);
+            CommandManager commandManager = new CommandManager(commandContributionContext, commandInterceptorContext);
             GuildPropertyManager guildPropertyManager = new GuildPropertyManager(guildPropertyContext);
             GuildManager guildManager = new GuildManager(guildPropertyManager, mode);
             AudioManager audioManager = new AudioManager(youTubeService, sessionFactory, commandManager, guildManager);

--- a/src/main/java/net/robinfriedli/botify/command/commands/PropertyCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PropertyCommand.java
@@ -10,9 +10,9 @@ import net.robinfriedli.botify.command.AbstractCommand;
 import net.robinfriedli.botify.command.ArgumentContribution;
 import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
-import net.robinfriedli.botify.discord.GuildContext;
 import net.robinfriedli.botify.discord.properties.AbstractGuildProperty;
 import net.robinfriedli.botify.discord.properties.GuildPropertyManager;
+import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.botify.util.Table2;
@@ -65,13 +65,13 @@ public class PropertyCommand extends AbstractCommand {
     private void listProperties() {
         GuildPropertyManager guildPropertyManager = Botify.get().getGuildPropertyManager();
         List<AbstractGuildProperty> properties = guildPropertyManager.getProperties();
-        GuildContext guildContext = getContext().getGuildContext();
+        GuildSpecification specification = getContext().getGuildContext().getSpecification();
 
         EmbedBuilder embedBuilder = new EmbedBuilder();
         Table2 table = new Table2(embedBuilder);
         table.addColumn("Name", properties, AbstractGuildProperty::getName);
         table.addColumn("Default Value", properties, AbstractGuildProperty::getDefaultValue);
-        table.addColumn("Set Value", properties, property -> String.valueOf(property.extractPersistedValue(guildContext.getSpecification())));
+        table.addColumn("Set Value", properties, property -> String.valueOf(property.extractPersistedValue(specification)));
         table.build();
         sendMessage(embedBuilder);
     }

--- a/src/main/java/net/robinfriedli/botify/discord/properties/AbstractGuildProperty.java
+++ b/src/main/java/net/robinfriedli/botify/discord/properties/AbstractGuildProperty.java
@@ -50,9 +50,8 @@ public abstract class AbstractGuildProperty {
     public void set(String value, GuildContext guildContext) {
         StaticSessionProvider.invokeWithSession(session -> {
             guildContext.getInvoker().invoke(session, () -> {
-                GuildSpecification guildSpecification = guildContext.getSpecification();
+                GuildSpecification guildSpecification = guildContext.getSpecification(session);
                 setValue(value, guildSpecification);
-                session.merge(guildSpecification);
             });
         });
     }
@@ -61,15 +60,14 @@ public abstract class AbstractGuildProperty {
 
     /**
      * @return the persisted value of the property if not null or default value. Mind that this implementation relies on this method
-     * being called by a thread with a command context set up. Use {@link #get(GuildContext)} instead to
-     * define the target GuildContext explicitly when this is not the case.
+     * being called by a thread with a command context set up. Use {@link #get(GuildSpecification)} instead to
+     * define the target GuildSpecification explicitly when this is not the case.
      */
     public Object get() {
-        return get(CommandContext.Current.require().getGuildContext());
+        return get(CommandContext.Current.require().getGuildContext().getSpecification());
     }
 
-    public Object get(GuildContext guildContext) {
-        GuildSpecification specification = guildContext.getSpecification();
+    public Object get(GuildSpecification specification) {
         Object persistedValue = extractPersistedValue(specification);
         if (persistedValue != null) {
             return persistedValue;

--- a/src/main/java/net/robinfriedli/botify/discord/properties/ColorSchemeProperty.java
+++ b/src/main/java/net/robinfriedli/botify/discord/properties/ColorSchemeProperty.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 
 import net.robinfriedli.botify.Botify;
 import net.robinfriedli.botify.command.CommandContext;
-import net.robinfriedli.botify.discord.GuildContext;
 import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.entities.xml.GuildPropertyContribution;
 import net.robinfriedli.botify.exceptions.InvalidPropertyValueException;
@@ -17,10 +16,10 @@ public class ColorSchemeProperty extends AbstractGuildProperty {
         super(contribution);
     }
 
-    public static Color getColor(GuildContext guildContext) {
+    public static Color getColor(GuildSpecification guildSpecification) {
         ColorSchemeProperty colorProperty = (ColorSchemeProperty) Botify.get().getGuildPropertyManager().getProperty("color");
         if (colorProperty != null) {
-            return colorProperty.getAsColor(guildContext);
+            return colorProperty.getAsColor(guildSpecification);
         } else {
             return DEFAULT_FALLBACK;
         }
@@ -82,8 +81,8 @@ public class ColorSchemeProperty extends AbstractGuildProperty {
         return parseColor((String) get());
     }
 
-    public Color getAsColor(GuildContext guildContext) {
-        return parseColor((String) get(guildContext));
+    public Color getAsColor(GuildSpecification guildSpecification) {
+        return parseColor((String) get(guildSpecification));
     }
 
 }

--- a/src/main/java/net/robinfriedli/botify/entities/AccessConfiguration.java
+++ b/src/main/java/net/robinfriedli/botify/entities/AccessConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -23,9 +24,13 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Role;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
 @Table(name = "access_configuration")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class AccessConfiguration implements Serializable {
 
     @Id
@@ -35,6 +40,7 @@ public class AccessConfiguration implements Serializable {
     @Column(name = "command_identifier", nullable = false)
     private String commandIdentifier;
     @OneToMany(mappedBy = "accessConfiguration", fetch = FetchType.EAGER)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Set<GrantedRole> roles = Sets.newHashSet();
     @ManyToOne
     @JoinColumn(name = "guild_specification_pk", referencedColumnName = "pk", foreignKey = @ForeignKey(name = "fk_guild_specification"))

--- a/src/main/java/net/robinfriedli/botify/entities/GuildSpecification.java
+++ b/src/main/java/net/robinfriedli/botify/entities/GuildSpecification.java
@@ -5,9 +5,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -17,9 +17,13 @@ import javax.persistence.Table;
 import com.google.api.client.util.Sets;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Guild;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
 @Table(name = "guild_specification")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class GuildSpecification implements Serializable {
 
     @Id
@@ -44,7 +48,7 @@ public class GuildSpecification implements Serializable {
     private String defaultSource;
     @Column(name = "default_list_source")
     private String defaultListSource;
-    @OneToMany(mappedBy = "guildSpecification", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "guildSpecification")
     private Set<AccessConfiguration> accessConfigurations = Sets.newHashSet();
 
     public GuildSpecification() {

--- a/src/main/java/net/robinfriedli/botify/entities/PlaybackHistory.java
+++ b/src/main/java/net/robinfriedli/botify/entities/PlaybackHistory.java
@@ -7,7 +7,6 @@ import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.FlushModeType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -45,7 +44,7 @@ public class PlaybackHistory implements Serializable {
     private String guild;
     @Column(name = "guild_id")
     private String guildId;
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany
     private Set<Artist> artists = Sets.newHashSet();
 
     public PlaybackHistory() {

--- a/src/main/java/net/robinfriedli/botify/entities/Preset.java
+++ b/src/main/java/net/robinfriedli/botify/entities/Preset.java
@@ -2,6 +2,7 @@ package net.robinfriedli.botify.entities;
 
 import java.io.Serializable;
 
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -16,9 +17,13 @@ import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
 import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
 @Table(name = "preset")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class Preset implements Serializable {
 
     @Id

--- a/src/main/java/net/robinfriedli/botify/entities/Song.java
+++ b/src/main/java/net/robinfriedli/botify/entities/Song.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.FlushModeType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -36,7 +35,7 @@ public class Song extends PlaylistItem {
     private String id;
     @Column(name = "name")
     private String name;
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany
     private Set<Artist> artists = Sets.newHashSet();
 
     public Song() {

--- a/src/main/java/net/robinfriedli/botify/listeners/GuildJoinListener.java
+++ b/src/main/java/net/robinfriedli/botify/listeners/GuildJoinListener.java
@@ -66,6 +66,9 @@ public class GuildJoinListener extends ListenerAdapter {
     @Override
     public void onGuildJoin(GuildJoinEvent event) {
         Guild guild = event.getGuild();
+        guildManager.addGuild(guild);
+        executionQueueManager.addGuild(guild);
+
         MessageService messageService = new MessageService();
         try (Context context = jxpBackend.createLazyContext(PropertiesLoadingService.requireProperty("EMBED_DOCUMENTS_PATH"))) {
             EmbedDocumentContribution embedDocumentContribution = context
@@ -76,9 +79,6 @@ public class GuildJoinListener extends ListenerAdapter {
         } catch (Throwable e) {
             logger.error("Error sending getting started message", e);
         }
-
-        guildManager.addGuild(guild);
-        executionQueueManager.addGuild(guild);
 
         if (discordBotListAPI != null) {
             discordBotListAPI.setStats(event.getJDA().getGuilds().size());

--- a/src/main/java/net/robinfriedli/botify/listeners/VoiceChannelListener.java
+++ b/src/main/java/net/robinfriedli/botify/listeners/VoiceChannelListener.java
@@ -7,10 +7,11 @@ import net.dv8tion.jda.core.hooks.ListenerAdapter;
 import net.robinfriedli.botify.Botify;
 import net.robinfriedli.botify.audio.AudioManager;
 import net.robinfriedli.botify.audio.AudioPlayback;
-import net.robinfriedli.botify.discord.GuildContext;
 import net.robinfriedli.botify.discord.GuildManager;
 import net.robinfriedli.botify.discord.properties.AbstractGuildProperty;
 import net.robinfriedli.botify.discord.properties.GuildPropertyManager;
+import net.robinfriedli.botify.entities.GuildSpecification;
+import net.robinfriedli.botify.util.StaticSessionProvider;
 
 public class VoiceChannelListener extends ListenerAdapter {
 
@@ -41,15 +42,17 @@ public class VoiceChannelListener extends ListenerAdapter {
     }
 
     private boolean isAutoPauseEnabled(Guild guild) {
-        GuildPropertyManager guildPropertyManager = Botify.get().getGuildPropertyManager();
-        GuildManager guildManager = Botify.get().getGuildManager();
-        GuildContext guildContext = guildManager.getContextForGuild(guild);
-        AbstractGuildProperty enableAutoPauseProperty = guildPropertyManager.getProperty("enableAutoPause");
-        if (enableAutoPauseProperty != null) {
-            return (boolean) enableAutoPauseProperty.get(guildContext);
-        }
+        return StaticSessionProvider.invokeWithSession(session -> {
+            GuildPropertyManager guildPropertyManager = Botify.get().getGuildPropertyManager();
+            GuildManager guildManager = Botify.get().getGuildManager();
+            GuildSpecification specification = guildManager.getContextForGuild(guild).getSpecification(session);
+            AbstractGuildProperty enableAutoPauseProperty = guildPropertyManager.getProperty("enableAutoPause");
+            if (enableAutoPauseProperty != null) {
+                return (boolean) enableAutoPauseProperty.get(specification);
+            }
 
-        return true;
+            return true;
+        });
     }
 
 }

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ehcache>
+  <cache name="net.robinfriedli.botify.entities.GuildSpecification"
+         maxEntriesLocalHeap="10000"
+         eternal="false"
+         timeToLiveSeconds="3600">
+    <persistence strategy="localTempSwap"/>
+  </cache>
+  <cache name="net.robinfriedli.botify.entities.AccessConfiguration"
+         maxEntriesLocalHeap="20000"
+         eternal="false"
+         timeToLiveSeconds="3600">
+    <persistence strategy="localTempSwap"/>
+  </cache>
+  <cache name="net.robinfriedli.botify.entities.AccessConfiguration.roles"
+         maxEntriesLocalHeap="40000"
+         eternal="false"
+         timeToLiveSeconds="3600">
+    <persistence strategy="localTempSwap"/>
+  </cache>
+  <cache name="net.robinfriedli.botify.entities.Preset"
+         maxEntriesLocalHeap="50000"
+         eternal="true">
+    <persistence strategy="localTempSwap"/>
+  </cache>
+</ehcache>


### PR DESCRIPTION
 - use jcache and ehcache caching and no longer keep an initialized
   GuildSpecification instance on the GuildContext but load it from
   the cache instead
   - caching the instance as field was not a good idea as handling the
     detached instance caused issues. For instance, when a verification
     of a property value failed and rolled back the invalid changes
     were still stored on the GuildSpecification instance, breaking the
     property until restart of the bot.
   - access configurations are now cached along with their roles
 - making sure GuildSpecifications are generally operated upon in the
   same session as the one that created them
   - merges are no longer needed and LazyInitiationExceptions with the
     new proxies created by the newly used load method avoided
 - remove unnecessary EAGER FetchTypes
   - only really needed on AccessConfigurations for GrantedRoles, as
     they are always needed when loading the access configuration