### PR TITLE
fix behaviour of AudioManager#playTrack when skipping paused tracks

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/AudioManager.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioManager.java
@@ -59,13 +59,9 @@ public class AudioManager {
             throw new InvalidCommandException("Not in a voice channel");
         }
 
-        if (!playback.isPaused()) {
-            QueueIterator queueIterator = new QueueIterator(playback, this);
-            playback.setCurrentQueueIterator(queueIterator);
-            queueIterator.playNext();
-        } else {
-            playback.unpause();
-        }
+        QueueIterator queueIterator = new QueueIterator(playback, this);
+        playback.setCurrentQueueIterator(queueIterator);
+        queueIterator.playNext();
     }
 
     public AudioPlayback getPlaybackForGuild(Guild guild) {

--- a/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
@@ -41,7 +41,9 @@ public class PlayCommand extends AbstractQueueLoadingCommand {
         playbackForGuild.setCommunicationChannel(messageChannel);
 
         if (getCommandBody().isBlank()) {
-            if (playbackForGuild.isPaused() || !audioManager.getQueue(guild).isEmpty()) {
+            if (playbackForGuild.isPaused()) {
+                playbackForGuild.unpause();
+            } else if (!audioManager.getQueue(guild).isEmpty()) {
                 audioManager.playTrack(guild, channel);
             } else {
                 throw new InvalidCommandException("Queue is empty. Specify a song you want to play.");

--- a/src/main/java/net/robinfriedli/botify/command/widgets/actions/PlayPauseAction.java
+++ b/src/main/java/net/robinfriedli/botify/command/widgets/actions/PlayPauseAction.java
@@ -25,9 +25,11 @@ public class PlayPauseAction extends AbstractWidgetAction {
 
     @Override
     protected void handleReaction(GuildMessageReactionAddEvent event) {
-        if (audioPlayback.isPlaying()) {
+        if (audioPlayback.isPaused()) {
+            audioPlayback.unpause();
+        } else if (audioPlayback.isPlaying()) {
             audioPlayback.pause();
-        } else if (!audioPlayback.getAudioQueue().isEmpty() || audioPlayback.isPaused()) {
+        } else if (!audioPlayback.getAudioQueue().isEmpty()) {
             User user = event.getUser();
             Guild guild = event.getGuild();
             audioManager.playTrack(guild, guild.getMember(user).getVoiceState().getChannel());


### PR DESCRIPTION
 - the behaviour of this method was changed in v1.6 from starting to
   play the current track in the queue to automatically unpausing the
   playback yet the skip and rewind commands relied on the old behaviour
   so when using these commands while the playback is paused it would
   just change the queue index and resume to play the current track