### PR TITLE
fix ExportCommand

### DIFF
--- a/src/main/java/net/robinfriedli/botify/command/commands/ExportCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/ExportCommand.java
@@ -53,7 +53,7 @@ public class ExportCommand extends AbstractCommand {
             }
         }
         String playlistSizeMax = PropertiesLoadingService.loadProperty("PLAYLIST_SIZE_MAX");
-        if (Strings.isNullOrEmpty(playlistSizeMax)) {
+        if (!Strings.isNullOrEmpty(playlistSizeMax)) {
             int maxSize = Integer.parseInt(playlistSizeMax);
             if (tracks.size() > maxSize) {
                 throw new InvalidCommandException("List exceeds maximum size of " + maxSize + " items!");
@@ -64,6 +64,8 @@ public class ExportCommand extends AbstractCommand {
         Playlist playlist = new Playlist(getCommandBody(), createUser, guild);
 
         invoke(() -> {
+            session.persist(playlist);
+
             for (Playable track : tracks) {
                 if (track instanceof HollowYouTubeVideo) {
                     HollowYouTubeVideo video = (HollowYouTubeVideo) track;
@@ -76,8 +78,6 @@ public class ExportCommand extends AbstractCommand {
                 export.add();
                 session.persist(export);
             }
-
-            session.persist(playlist);
         });
     }
 


### PR DESCRIPTION
 - persist playlist before the playlist items to avoid a
   TransientObjectException when the query for artists when initializing
   a Song causes a flush
 - fix an if statement that was not inverted which meant playlist size was
   not checked