### PR TITLE
optimise ThreadExecutionQueue

### DIFF
--- a/src/main/java/net/robinfriedli/botify/concurrent/QueuedThread.java
+++ b/src/main/java/net/robinfriedli/botify/concurrent/QueuedThread.java
@@ -17,9 +17,7 @@ public class QueuedThread extends Thread {
         try {
             super.run();
         } finally {
-            if (!isPrivileged()) {
-                queue.freeSlot(this);
-            }
+            queue.freeSlot(this);
         }
     }
 

--- a/src/main/java/net/robinfriedli/botify/concurrent/ThreadExecutionQueue.java
+++ b/src/main/java/net/robinfriedli/botify/concurrent/ThreadExecutionQueue.java
@@ -29,12 +29,17 @@ public class ThreadExecutionQueue {
     public boolean add(QueuedThread thread) {
         synchronized (synchroniseLock) {
             if (!closed) {
-                queue.add(thread);
-                if (currentPool.size() < size) {
-                    runNext();
+                if (thread.isPrivileged()) {
+                    currentPool.add(thread);
+                    thread.start();
                     return true;
+                } else {
+                    queue.add(thread);
+                    if (currentPool.size() < size) {
+                        runNext();
+                        return true;
+                    }
                 }
-
                 return false;
             } else {
                 throw new IllegalStateException("This " + getClass().getSimpleName() + " has been closed");


### PR DESCRIPTION
 - add privileged commands to the current pool so they can still be
   monitored and joined
   - the cleandb command had an error where the clean database thread
     would start before the cleandb command thread finished, causing
     the database cleanup thread to use the same session as the command
     that created it because it didn't wait for it to close it
 - do not send an error when a user enters a command that does not exist
   as most of the time that means the bot was not meant to be invoked