### PR TITLE
QueueWidget: make sure message is accessed before it's deleted

### DIFF
--- a/src/main/java/net/robinfriedli/botify/command/widgets/QueueWidget.java
+++ b/src/main/java/net/robinfriedli/botify/command/widgets/QueueWidget.java
@@ -46,6 +46,8 @@ public class QueueWidget extends AbstractWidget {
 
     @Override
     public void reset() throws Exception {
+        EmbedBuilder embedBuilder = audioPlayback.getAudioQueue().buildMessageEmbed(audioPlayback, getMessage().getGuild());
+
         setMessageDeleted(true);
         try {
             getMessage().delete().queue();
@@ -53,7 +55,6 @@ public class QueueWidget extends AbstractWidget {
             throw new UserException("Bot is missing permission: " + e.getPermission().getName(), e);
         }
 
-        EmbedBuilder embedBuilder = audioPlayback.getAudioQueue().buildMessageEmbed(audioPlayback, getMessage().getGuild());
         MessageService messageService = new MessageService();
         CompletableFuture<Message> futureMessage = messageService.sendWithLogo(embedBuilder, getMessage().getChannel());
         getCommandManager().registerWidget(new QueueWidget(getCommandManager(), futureMessage.get(), audioManager, audioPlayback));


### PR DESCRIPTION
 - a race condition could throw an error when the message was deleted
   after completing the widget action before the
   CompletablePlaceholderMessage was completed
   - if the message was deleted too early the constructor of the
     AlertPresetCreationInterceptor threw an exception when trying to
     access the message
     - AudioQueue#buildMessageEmbed created a session to load the color
       property which caused the instantiation of the interceptor chain.
       Now AudioQueue#buildMessageEmbed is called before deleting the
       message