### PR TITLE
CleanDbCommand: ensure session is closed after

### DIFF
--- a/src/main/java/net/robinfriedli/botify/command/commands/admin/CleanDbCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/admin/CleanDbCommand.java
@@ -66,6 +66,7 @@ public class CleanDbCommand extends AbstractAdminCommand {
 
                     doClean();
                 } finally {
+                    context.closeSession();
                     Botify.registerListeners();
                 }
             });


### PR DESCRIPTION
 - the cleanup thread typically finishes after the CommandManager calls
   CommandContext#closeSession after executing the command interceptor
   chain, causing it to open a fresh session