### PR TITLE
introduce cron jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,18 +29,18 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-youtube</artifactId>
-      <version>v3-rev209-1.25.0</version>
+      <version>v3-rev212-1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>28.0-jre</version>
+      <version>28.1-jre</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sedmelluq</groupId>
       <artifactId>lavaplayer</artifactId>
-      <version>1.3.20</version>
+      <version>1.3.21</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -73,15 +73,20 @@
       <version>42.2.2.jre7</version>
     </dependency>
     <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <version>2.3.1</version>
+    </dependency>
+    <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>4.0.0_39</version>
+      <version>4.0.0_46</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>net.robinfriedli.JXP</groupId>
       <artifactId>JXP</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>net.robinfriedli.StringList</groupId>
@@ -96,7 +101,7 @@
     <dependency>
       <groupId>se.michaelthelin.spotify</groupId>
       <artifactId>spotify-web-api-java</artifactId>
-      <version>2.2.0</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/resources/schemas/cronJobSchema.xsd
+++ b/resources/schemas/cronJobSchema.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="cronJobSpace">
+
+  <xs:element name="cronJobs" type="cronJobs"/>
+  <xs:complexType name="cronJobs">
+    <xs:sequence>
+      <xs:element name="cronJob" type="cronJob"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="cronJob">
+    <xs:sequence>
+      <xs:element name="cronParameter" type="cronParameter"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="cron" type="xs:string"/>
+    <xs:attribute name="implementation" type="xs:string"/>
+  </xs:complexType>
+  <xs:complexType name="cronParameter">
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="implementation" type="xs:string"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/resources/xml-contributions/cronJobs.xml
+++ b/resources/xml-contributions/cronJobs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<cronJobs xmlns="cronJobSpace">
+  <cronJob id="playbackCleanup" cron="0 */15 * * * ? *" implementation="net.robinfriedli.botify.cron.PlaybackCleanupTask">
+    <cronParameter name="audioManager" implementation="net.robinfriedli.botify.audio.AudioManager"/>
+    <cronParameter name="guildManager" implementation="net.robinfriedli.botify.discord.GuildManager"/>
+    <cronParameter name="jda" implementation="net.dv8tion.jda.api.JDA"/>
+  </cronJob>
+</cronJobs>

--- a/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
@@ -1,8 +1,11 @@
 package net.robinfriedli.botify.audio;
 
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+
+import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +32,10 @@ public class AudioPlayback {
     private MessageChannel communicationChannel;
     private Message lastPlaybackNotification;
     private QueueIterator currentQueueIterator;
+
+    // time the bot has been alone in the voice channel since
+    @Nullable
+    private LocalDateTime aloneSince;
 
     public AudioPlayback(AudioPlayer player, Guild guild) {
         this.guild = guild;
@@ -128,6 +135,17 @@ public class AudioPlayback {
         audioPlayer.setVolume(volume);
     }
 
+    /**
+     * Clear the queue and reset all options
+     */
+    public void clear() {
+        getAudioQueue().clear();
+        setVolume(100);
+        setShuffle(false);
+        setRepeatAll(false);
+        setRepeatOne(false);
+    }
+
     public void setLastPlaybackNotification(Message message) {
         if (lastPlaybackNotification != null) {
             try {
@@ -154,5 +172,14 @@ public class AudioPlayback {
 
         currentQueueIterator = queueIterator;
         audioPlayer.addListener(queueIterator);
+    }
+
+    @Nullable
+    public LocalDateTime getAloneSince() {
+        return aloneSince;
+    }
+
+    public void setAloneSince(@Nullable LocalDateTime aloneSince) {
+        this.aloneSince = aloneSince;
     }
 }

--- a/src/main/java/net/robinfriedli/botify/cron/AbstractCronTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/AbstractCronTask.java
@@ -1,0 +1,40 @@
+package net.robinfriedli.botify.cron;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+
+public abstract class AbstractCronTask implements Job {
+
+    private final Logger logger;
+    private JobExecutionContext jobExecutionContext;
+
+    public AbstractCronTask() {
+        logger = LoggerFactory.getLogger(getClass());
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) {
+        this.jobExecutionContext = jobExecutionContext;
+        try {
+            run(jobExecutionContext);
+        } catch (Throwable e) {
+            logger.error("Error in cron job", e);
+        }
+    }
+
+    protected abstract void run(JobExecutionContext jobExecutionContext) throws Exception;
+
+    @SuppressWarnings("unchecked")
+    protected <E> E getParameter(Class<E> type) {
+        JobDataMap jobDataMap = jobExecutionContext.getMergedJobDataMap();
+        Optional<Object> mappedParameter = jobDataMap.values().stream().filter(type::isInstance).findFirst();
+        return (E) mappedParameter.orElseThrow();
+    }
+
+}

--- a/src/main/java/net/robinfriedli/botify/cron/CronJobService.java
+++ b/src/main/java/net/robinfriedli/botify/cron/CronJobService.java
@@ -1,0 +1,51 @@
+package net.robinfriedli.botify.cron;
+
+import java.util.List;
+
+import net.robinfriedli.botify.entities.xml.CronJobContribution;
+import net.robinfriedli.botify.util.Cache;
+import net.robinfriedli.jxp.persist.Context;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+
+public class CronJobService {
+
+    private final Context contributionContext;
+    private final Scheduler scheduler;
+
+    public CronJobService(Context contributionContext) throws SchedulerException {
+        this.contributionContext = contributionContext;
+        this.scheduler = StdSchedulerFactory.getDefaultScheduler();
+        scheduler.start();
+    }
+
+    public void scheduleAll() throws SchedulerException {
+        List<CronJobContribution> contributions = contributionContext.getInstancesOf(CronJobContribution.class);
+        for (CronJobContribution contribution : contributions) {
+            JobDataMap jobDataMap = new JobDataMap();
+            List<CronJobContribution.CronParameter> parameters = contribution.getInstancesOf(CronJobContribution.CronParameter.class);
+            for (CronJobContribution.CronParameter parameter : parameters) {
+                jobDataMap.put(parameter.getName(), Cache.get(parameter.getImplementationClass()));
+            }
+
+            JobDetail jobDetail = JobBuilder.newJob(contribution.getImplementationClass())
+                .withIdentity(contribution.getId())
+                .setJobData(jobDataMap)
+                .build();
+
+            CronTrigger trigger = TriggerBuilder
+                .newTrigger()
+                .withSchedule(CronScheduleBuilder.cronSchedule(contribution.getCronExpression()))
+                .build();
+            scheduler.scheduleJob(jobDetail, trigger);
+        }
+    }
+
+}

--- a/src/main/java/net/robinfriedli/botify/cron/PlaybackCleanupTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/PlaybackCleanupTask.java
@@ -1,0 +1,61 @@
+package net.robinfriedli.botify.cron;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.robinfriedli.botify.audio.AudioManager;
+import net.robinfriedli.botify.audio.AudioPlayback;
+import net.robinfriedli.botify.discord.GuildContext;
+import net.robinfriedli.botify.discord.GuildManager;
+import net.robinfriedli.botify.util.StaticSessionProvider;
+import org.quartz.JobExecutionContext;
+
+public class PlaybackCleanupTask extends AbstractCronTask {
+
+    @Override
+    public void run(JobExecutionContext jobExecutionContext) {
+        Logger logger = LoggerFactory.getLogger(getClass());
+        logger.info("Starting playback cleanup");
+        AudioManager audioManager = getParameter(AudioManager.class);
+        GuildManager guildManager = getParameter(GuildManager.class);
+        Collection<GuildContext> guildContexts = guildManager.getGuildContexts();
+
+        int clearedAlone = 0;
+        for (GuildContext guildContext : guildContexts) {
+            AudioPlayback playback = guildContext.getPlayback();
+            LocalDateTime aloneSince = playback.getAloneSince();
+            if (aloneSince != null) {
+                Duration aloneSinceDuration = Duration.between(aloneSince, LocalDateTime.now());
+                Duration oneHour = Duration.ofHours(1);
+                if (aloneSinceDuration.compareTo(oneHour) > 0) {
+                    playback.stop();
+                    audioManager.leaveChannel(playback);
+                    playback.setAloneSince(null);
+                    playback.clear();
+                    ++clearedAlone;
+                }
+            }
+        }
+
+        Set<Guild> activeGuilds = StaticSessionProvider.invokeWithSession(session -> {
+            return guildManager.getActiveGuilds(session, 3600000);
+        });
+
+        for (GuildContext guildContext : guildContexts) {
+            AudioPlayback playback = guildContext.getPlayback();
+            if (!activeGuilds.contains(playback.getGuild())) {
+                playback.clear();
+            }
+        }
+
+        if (clearedAlone > 0) {
+            logger.info("Stopped " + clearedAlone + " lone playbacks.");
+        }
+    }
+}

--- a/src/main/java/net/robinfriedli/botify/discord/MessageService.java
+++ b/src/main/java/net/robinfriedli/botify/discord/MessageService.java
@@ -118,7 +118,7 @@ public class MessageService {
 
     public CompletableFuture<Message> sendWithLogo(EmbedBuilder embedBuilder, MessageChannel channel) {
         String baseUri = PropertiesLoadingService.requireProperty("BASE_URI");
-        embedBuilder.setThumbnail(baseUri + "/resources-public/img/botify-logo-small.png");
+        embedBuilder.setThumbnail(baseUri + "/resources-public/img/botify-logo.png");
         embedBuilder.setColor(ColorSchemeProperty.getColor());
         return send(embedBuilder.build(), channel);
     }
@@ -127,7 +127,7 @@ public class MessageService {
         String baseUri = PropertiesLoadingService.requireProperty("BASE_URI");
         embedBuilder.setThumbnail(baseUri + "/resources-public/img/botify-logo.png");
         embedBuilder.setColor(ColorSchemeProperty.getColor());
-        return send(embedBuilder, guild);
+        return send(embedBuilder.build(), guild);
     }
 
     public CompletableFuture<Message> send(MessageBuilder messageBuilder, InputStream file, String fileName, MessageChannel messageChannel) {

--- a/src/main/java/net/robinfriedli/botify/entities/xml/CronJobContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/CronJobContribution.java
@@ -1,0 +1,54 @@
+package net.robinfriedli.botify.entities.xml;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import net.robinfriedli.botify.cron.AbstractCronTask;
+import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.persist.Context;
+import org.w3c.dom.Element;
+
+public class CronJobContribution extends GenericClassContribution<AbstractCronTask> {
+
+    // invoked by JXP
+    @SuppressWarnings("unused")
+    public CronJobContribution(Element element, Context context) {
+        super(element, context);
+    }
+
+    // invoked by JXP
+    @SuppressWarnings("unused")
+    public CronJobContribution(Element element, List<XmlElement> subElements, Context context) {
+        super(element, subElements, context);
+    }
+
+    @Override
+    public String getId() {
+        return getAttribute("id").getValue();
+    }
+
+    public String getCronExpression() {
+        return getAttribute("cron").getValue();
+    }
+
+    public static class CronParameter extends GenericClassContribution<Object> {
+
+        // invoked by JXP
+        @SuppressWarnings("unused")
+        public CronParameter(Element element, Context context) {
+            super(element, context);
+        }
+
+        @Nullable
+        @Override
+        public String getId() {
+            return getName();
+        }
+
+        public String getName() {
+            return getAttribute("name").getValue();
+        }
+    }
+
+}

--- a/src/main/java/net/robinfriedli/botify/entities/xml/GenericClassContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/GenericClassContribution.java
@@ -26,7 +26,7 @@ public abstract class GenericClassContribution<E> extends AbstractXmlElement {
     }
 
     @SuppressWarnings("unchecked")
-    public E instantiate() {
+    public Class<E> getImplementationClass() {
         Class<E> implementation;
         String className = getAttribute("implementation").getValue();
         try {
@@ -37,9 +37,16 @@ public abstract class GenericClassContribution<E> extends AbstractXmlElement {
             throw new IllegalStateException("Could not cast class " + className + " to the target class", e);
         }
 
+        return implementation;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E instantiate() {
+        Class<E> implementation = getImplementationClass();
+
         Constructor<?>[] constructors = implementation.getConstructors();
         if (constructors.length == 0) {
-            throw new IllegalStateException("Class " + className + " does not have any public constructors");
+            throw new IllegalStateException("Class " + implementation + " does not have any public constructors");
         }
 
         Constructor<E> constructor = (Constructor<E>) constructors[0];

--- a/src/main/java/net/robinfriedli/botify/listeners/CommandListener.java
+++ b/src/main/java/net/robinfriedli/botify/listeners/CommandListener.java
@@ -24,6 +24,7 @@ import net.robinfriedli.botify.discord.GuildManager;
 import net.robinfriedli.botify.discord.MessageService;
 import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.exceptions.UserException;
+import net.robinfriedli.botify.exceptions.handlers.LoggingExceptionHandler;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
@@ -50,7 +51,11 @@ public class CommandListener extends ListenerAdapter {
                            SpotifyApi.Builder spotifyApiBuilder) {
         this.executionQueueManager = executionQueueManager;
         this.commandManager = commandManager;
-        this.commandConceptionPool = Executors.newCachedThreadPool();
+        this.commandConceptionPool = Executors.newCachedThreadPool(r -> {
+            Thread thread = new Thread(r);
+            thread.setUncaughtExceptionHandler(new LoggingExceptionHandler());
+            return thread;
+        });
         this.guildManager = guildManager;
         this.messageService = messageService;
         this.sessionFactory = sessionFactory;

--- a/src/main/java/net/robinfriedli/botify/listeners/GuildJoinListener.java
+++ b/src/main/java/net/robinfriedli/botify/listeners/GuildJoinListener.java
@@ -1,8 +1,5 @@
 package net.robinfriedli.botify.listeners;
 
-import java.io.File;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -12,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.wrapper.spotify.SpotifyApi;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
@@ -20,24 +16,11 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.robinfriedli.botify.discord.CommandExecutionQueueManager;
 import net.robinfriedli.botify.discord.GuildManager;
 import net.robinfriedli.botify.discord.MessageService;
-import net.robinfriedli.botify.entities.Playlist;
-import net.robinfriedli.botify.entities.PlaylistItem;
-import net.robinfriedli.botify.entities.xml.EmbedDocumentContribution;
 import net.robinfriedli.botify.exceptions.handlers.LoggingExceptionHandler;
-import net.robinfriedli.botify.interceptors.InterceptorChain;
-import net.robinfriedli.botify.interceptors.PlaylistItemTimestampListener;
-import net.robinfriedli.botify.interceptors.VerifyPlaylistListener;
-import net.robinfriedli.botify.tasks.HibernatePlaylistMigrator;
-import net.robinfriedli.botify.util.PropertiesLoadingService;
-import net.robinfriedli.botify.util.SearchEngine;
 import net.robinfriedli.jxp.api.JxpBackend;
-import net.robinfriedli.jxp.persist.Context;
 import org.discordbots.api.client.DiscordBotListAPI;
-import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.jetbrains.annotations.NotNull;
-
-import static net.robinfriedli.jxp.queries.Conditions.*;
 
 /**
  * Listener responsible for handling the bot joining or leaving a guild
@@ -84,50 +67,8 @@ public class GuildJoinListener extends ListenerAdapter {
             guildManager.addGuild(guild);
             executionQueueManager.addGuild(guild);
 
-            try (Context context = jxpBackend.createLazyContext(PropertiesLoadingService.requireProperty("EMBED_DOCUMENTS_PATH"))) {
-                EmbedDocumentContribution embedDocumentContribution = context
-                    .query(attribute("name").is("getting-started"), EmbedDocumentContribution.class)
-                    .requireOnlyResult();
-                EmbedBuilder embedBuilder = embedDocumentContribution.buildEmbed();
-                messageService.sendWithLogo(embedBuilder, guild);
-            } catch (Throwable e) {
-                logger.error("Error sending getting started message", e);
-            }
-
             if (discordBotListAPI != null) {
                 discordBotListAPI.setStats(event.getJDA().getGuilds().size());
-            }
-
-            try (Session session = sessionFactory.withOptions().interceptor(InterceptorChain.of(
-                PlaylistItemTimestampListener.class, VerifyPlaylistListener.class)).openSession()) {
-                String playlistsPath = PropertiesLoadingService.requireProperty("PLAYLISTS_PATH");
-                File file = new File(playlistsPath);
-                if (file.exists()) {
-                    Context context = jxpBackend.getContext(file);
-                    HibernatePlaylistMigrator hibernatePlaylistMigrator = new HibernatePlaylistMigrator(context, guild, spotifyApiBuilder.build(), session);
-                    Map<Playlist, List<PlaylistItem>> playlistMap;
-                    try {
-                        playlistMap = hibernatePlaylistMigrator.perform();
-                    } catch (Exception e) {
-                        logger.error("Exception while migrating hibernate playlists", e);
-                        session.close();
-                        return;
-                    }
-
-                    GuildManager.Mode mode = guildManager.getMode();
-                    session.beginTransaction();
-                    for (Playlist playlist : playlistMap.keySet()) {
-                        Playlist existingList = SearchEngine.searchLocalList(session, playlist.getName(), mode == GuildManager.Mode.PARTITIONED, guild.getId());
-                        if (existingList == null) {
-                            playlistMap.get(playlist).forEach(item -> {
-                                item.add();
-                                session.persist(item);
-                            });
-                            session.persist(playlist);
-                        }
-                    }
-                    session.getTransaction().commit();
-                }
             }
         });
     }

--- a/src/main/java/net/robinfriedli/botify/listeners/VoiceChannelListener.java
+++ b/src/main/java/net/robinfriedli/botify/listeners/VoiceChannelListener.java
@@ -1,7 +1,14 @@
 package net.robinfriedli.botify.listeners;
 
+import java.time.LocalDateTime;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.annotation.Nonnull;
+
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.robinfriedli.botify.Botify;
@@ -11,6 +18,7 @@ import net.robinfriedli.botify.discord.GuildManager;
 import net.robinfriedli.botify.discord.property.AbstractGuildProperty;
 import net.robinfriedli.botify.discord.property.GuildPropertyManager;
 import net.robinfriedli.botify.entities.GuildSpecification;
+import net.robinfriedli.botify.exceptions.handlers.LoggingExceptionHandler;
 import net.robinfriedli.botify.util.StaticSessionProvider;
 
 /**
@@ -19,23 +27,47 @@ import net.robinfriedli.botify.util.StaticSessionProvider;
 public class VoiceChannelListener extends ListenerAdapter {
 
     private final AudioManager audioManager;
+    private final ExecutorService executorService;
 
     public VoiceChannelListener(AudioManager audioManager) {
         this.audioManager = audioManager;
+        executorService = Executors.newCachedThreadPool(r -> {
+            Thread thread = new Thread(r);
+            thread.setUncaughtExceptionHandler(new LoggingExceptionHandler());
+            return thread;
+        });
     }
 
     @Override
     public void onGuildVoiceLeave(GuildVoiceLeaveEvent event) {
         if (!event.getMember().getUser().isBot()) {
-            VoiceChannel channel = event.getChannelLeft();
-            Guild guild = event.getGuild();
-            AudioPlayback playback = audioManager.getPlaybackForGuild(guild);
-            if (channel.equals(playback.getVoiceChannel())
-                && noOtherMembersLeft(channel, guild)
-                && isAutoPauseEnabled(guild)) {
-                playback.pause();
-                audioManager.leaveChannel(playback);
-            }
+            executorService.execute(() -> {
+                VoiceChannel channel = event.getChannelLeft();
+                Guild guild = event.getGuild();
+                AudioPlayback playback = audioManager.getPlaybackForGuild(guild);
+                if (channel.equals(playback.getVoiceChannel())
+                    && noOtherMembersLeft(channel, guild)) {
+                    if (isAutoPauseEnabled(guild)) {
+                        playback.pause();
+                        audioManager.leaveChannel(playback);
+                    } else {
+                        playback.setAloneSince(LocalDateTime.now());
+                    }
+                }
+            });
+        }
+    }
+
+    @Override
+    public void onGuildVoiceJoin(@Nonnull GuildVoiceJoinEvent event) {
+        if (!event.getMember().getUser().isBot()) {
+            executorService.execute(() -> {
+                Guild guild = event.getGuild();
+                AudioPlayback playback = audioManager.getPlaybackForGuild(guild);
+                if (event.getChannelJoined().equals(playback.getVoiceChannel())) {
+                    playback.setAloneSince(null);
+                }
+            });
         }
     }
 

--- a/src/main/resources/quartz.properties
+++ b/src/main/resources/quartz.properties
@@ -1,0 +1,3 @@
+org.quartz.scheduler.instanceName=QuartzScheduler
+org.quartz.threadPool.threadCount=3
+org.quartz.jobStore.class=org.quartz.simpl.RAMJobStore


### PR DESCRIPTION
 - create PlaybackCleanupTask to clean up all playbacks every 15
   minutes
   - removes the bot from voice channels were auto pause is off and
     the bot has been alone for 1 hour
   - clears all playbacks by clearing the queue and resetting repeat,
     shuffle and volume options for guilds that have been inactive
     for over an hour
 - refactor listeners
   - GuildJoinListener: instead of sending a getting-started message
     and creating the initial playlists when a guild joins, this is now
     done by the GuildManager when initializing a new guild without
     a persisted guild specification. This means that when guilds join
     while the bot is not running they will receive the getting started
     message and the playlists will be created once the bot starts and
     initializes the guild