### PR TITLE
AddCommand: do not redirect Spotify tracks

### DIFF
--- a/src/main/java/net/robinfriedli/botify/command/commands/AbstractQueueLoadingCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AbstractQueueLoadingCommand.java
@@ -1,0 +1,36 @@
+package net.robinfriedli.botify.command.commands;
+
+import net.robinfriedli.botify.command.ArgumentContribution;
+import net.robinfriedli.botify.command.CommandContext;
+import net.robinfriedli.botify.command.CommandManager;
+import net.robinfriedli.botify.entities.xml.CommandContribution;
+
+public abstract class AbstractQueueLoadingCommand extends AbstractPlayableLoadingCommand {
+
+    public AbstractQueueLoadingCommand(CommandContribution commandContribution, CommandContext context, CommandManager commandManager, String commandString, String identifier, String description, Category category, boolean mayInterrupt) {
+        super(commandContribution, context, commandManager, commandString, false, identifier, description, category, mayInterrupt);
+    }
+
+    @Override
+    protected boolean shouldRedirectSpotify() {
+        return !argumentSet("preview");
+    }
+
+    @Override
+    public ArgumentContribution setupArguments() {
+        ArgumentContribution argumentContribution = super.setupArguments();
+        argumentContribution.map("preview").setRequiresInput(true)
+            .setDescription("Load the short preview mp3 directly from Spotify instead of the full track from YouTube.")
+            .addRule(ac -> {
+                Source source = getSource();
+
+                if (ac.argumentSet("list")) {
+                    return source.isSpotify() || source.isLocal();
+                }
+
+                return source.isSpotify();
+            }, "Argument 'preview' may only be used with Spotify.");
+        return argumentContribution;
+    }
+
+}

--- a/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AddCommand.java
@@ -74,6 +74,11 @@ public class AddCommand extends AbstractPlayableLoadingCommand {
         addPlayables(playlist, playables);
     }
 
+    @Override
+    protected boolean shouldRedirectSpotify() {
+        return false;
+    }
+
     protected void addToList(Playlist playlist, List<PlaylistItem> items) {
         if (items.isEmpty()) {
             throw new NoResultsFoundException("Result is empty!");

--- a/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PlayCommand.java
@@ -17,10 +17,10 @@ import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.botify.exceptions.NoResultsFoundException;
 
-public class PlayCommand extends AbstractPlayableLoadingCommand {
+public class PlayCommand extends AbstractQueueLoadingCommand {
 
     public PlayCommand(CommandContribution commandContribution, CommandContext context, CommandManager commandManager, String commandString, String identifier, String description) {
-        super(commandContribution, context, commandManager, commandString, false, identifier, description, Category.PLAYBACK, true);
+        super(commandContribution, context, commandManager, commandString, identifier, description, Category.PLAYBACK, true);
     }
 
     @Override

--- a/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
@@ -24,10 +24,10 @@ import net.robinfriedli.botify.command.widgets.QueueWidget;
 import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.botify.exceptions.NoResultsFoundException;
 
-public class QueueCommand extends AbstractPlayableLoadingCommand {
+public class QueueCommand extends AbstractQueueLoadingCommand {
 
     public QueueCommand(CommandContribution commandContribution, CommandContext context, CommandManager commandManager, String commandString, String identifier, String description) {
-        super(commandContribution, context, commandManager, commandString, false, identifier, description, Category.PLAYBACK, false);
+        super(commandContribution, context, commandManager, commandString, identifier, description, Category.PLAYBACK, false);
     }
 
     @Override


### PR DESCRIPTION
 - after refactoring the AddCommand to extend the
   AbstractPlayableCommand Spotify tracks were redirected to YouTube
   videos unless the "preview" argument was set, which was not intended
   for the add command and slowed it down by quite a lot
   - the AbstractQueueLoadingCommand was reinstated as super class for
     the play and queue command for their shared code while now
     extending the AbstractPlayableCommand
   - the abstract method #shouldRedirectSpotify was added to the
     AbstractPlayableLoadingCommand which is implemented to return
     false for the AddCommand or return whether or not the "preview"
     argument is set for the AbstractQueueLoadingCommands