### PR TITLE
cleanup remaining imperfections

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/spotify/SpotifyRedirectService.java
+++ b/src/main/java/net/robinfriedli/botify/audio/spotify/SpotifyRedirectService.java
@@ -9,6 +9,7 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.wrapper.spotify.model_objects.specification.ArtistSimplified;
 import com.wrapper.spotify.model_objects.specification.Track;
 import net.robinfriedli.botify.audio.youtube.HollowYouTubeVideo;
@@ -69,7 +70,7 @@ public class SpotifyRedirectService {
         }
 
         youTubeService.redirectSpotify(youTubeVideo);
-        if (!youTubeVideo.isCanceled()) {
+        if (!youTubeVideo.isCanceled() && !Strings.isNullOrEmpty(spotifyTrack.getId())) {
             SINGE_THREAD_EXECUTOR_SERVICE.execute(() -> StaticSessionProvider.invokeWithSession(otherThreadSession -> {
                 try {
                     String videoId = youTubeVideo.getVideoId();

--- a/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
@@ -310,7 +310,7 @@ public abstract class AbstractCommand implements Command {
     }
 
     protected void sendToActiveGuilds(MessageEmbed message) {
-        messageService.sendToActiveGuilds(message, getContext().getJda(), Botify.get().getAudioManager(), getContext().getSession());
+        messageService.sendToActiveGuilds(message, getContext().getSession());
     }
 
     /**

--- a/src/main/java/net/robinfriedli/botify/command/interceptor/interceptors/HistoryInterceptor.java
+++ b/src/main/java/net/robinfriedli/botify/command/interceptor/interceptors/HistoryInterceptor.java
@@ -30,7 +30,7 @@ public class HistoryInterceptor extends AbstractChainableCommandInterceptor {
         history.setCommandIdentifier(command.getIdentifier());
         history.setWidget(command instanceof AbstractWidgetAction);
         history.setCommandBody(command instanceof AbstractCommand ? ((AbstractCommand) command).getCommandInput() : command.getCommandBody());
-        history.setInput(context.getMessage().getContentDisplay());
+        history.setInput(command instanceof AbstractCommand ? context.getMessage().getContentDisplay() : command.getCommandBody());
         history.setGuild(context.getGuild().getName());
         history.setGuildId(context.getGuild().getId());
         history.setUser(context.getUser().getName());

--- a/src/main/java/net/robinfriedli/botify/discord/MessageService.java
+++ b/src/main/java/net/robinfriedli/botify/discord/MessageService.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ChannelType;
@@ -33,7 +32,6 @@ import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.robinfriedli.botify.Botify;
-import net.robinfriedli.botify.audio.AudioManager;
 import net.robinfriedli.botify.discord.property.AbstractGuildProperty;
 import net.robinfriedli.botify.discord.property.GuildPropertyManager;
 import net.robinfriedli.botify.discord.property.properties.ColorSchemeProperty;
@@ -204,7 +202,7 @@ public class MessageService {
         }
     }
 
-    public void sendToActiveGuilds(MessageEmbed message, JDA jda, AudioManager audioManager, Session session) {
+    public void sendToActiveGuilds(MessageEmbed message, Session session) {
         GuildManager guildManager = Botify.get().getGuildManager();
         Set<Guild> activeGuilds = guildManager.getActiveGuilds(session);
 

--- a/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndex.java
+++ b/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndex.java
@@ -14,6 +14,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
+import com.google.common.base.Strings;
 import org.hibernate.Session;
 
 /**
@@ -46,6 +47,9 @@ public class SpotifyRedirectIndex implements Serializable {
     }
 
     public static Optional<SpotifyRedirectIndex> queryExistingIndex(Session session, String spotifyTrackId) {
+        if (Strings.isNullOrEmpty(spotifyTrackId)) {
+            return Optional.empty();
+        }
         CriteriaBuilder cb = session.getCriteriaBuilder();
         CriteriaQuery<SpotifyRedirectIndex> query = cb.createQuery(SpotifyRedirectIndex.class);
         Root<SpotifyRedirectIndex> root = query.from(SpotifyRedirectIndex.class);


### PR DESCRIPTION
 - remove unused parameters from MessageService#sendToActiveGuilds
 - prevent creation of SpotifyRedirectIndex if Spotify track id is
   empty
 - HistoryInterceptor: set emoji as input for WidgetActions