### PR TITLE
various minor improvements

### DIFF
--- a/resources/xml-contributions/cronJobs.xml
+++ b/resources/xml-contributions/cronJobs.xml
@@ -2,4 +2,5 @@
 <cronJobs xmlns="cronJobSpace">
   <cronJob id="playbackCleanup" cron="0 */15 * * * ? *" implementation="net.robinfriedli.botify.cron.tasks.PlaybackCleanupTask"/>
   <cronJob id="spotifyRedirectIndexRefresh" cron="0 0 3 * * ? *" implementation="net.robinfriedli.botify.cron.tasks.RefreshSpotifyRedirectIndicesTask"/>
+  <cronJob id="clearAbandonedGuildContexts" cron="0 */3 * * * ? *" implementation="net.robinfriedli.botify.cron.tasks.ClearAbandonedGuildContextsTask"/>
 </cronJobs>

--- a/src/main/java/net/robinfriedli/botify/audio/AudioManager.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioManager.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.robinfriedli.botify.audio.spotify.SpotifyService;
 import net.robinfriedli.botify.audio.youtube.YouTubeService;
+import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.widgets.NowPlayingWidget;
 import net.robinfriedli.botify.command.widgets.WidgetManager;
 import net.robinfriedli.botify.discord.GuildManager;
@@ -74,6 +75,10 @@ public class AudioManager {
             setChannel(playback, channel);
         } else if (playback.getVoiceChannel() == null) {
             throw new InvalidCommandException("Not in a voice channel");
+        }
+
+        if (CommandContext.Current.isSet()) {
+            playback.setCommunicationChannel(CommandContext.Current.require().getChannel());
         }
 
         if (playback.isPaused() && resumePaused) {

--- a/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
@@ -145,7 +145,7 @@ public class AudioPlayback {
     /**
      * Clear the queue and reset all options
      *
-     * @return true if anything change
+     * @return true if anything changed
      */
     public boolean clear() {
         boolean changedAnything = false;
@@ -178,6 +178,11 @@ public class AudioPlayback {
             voiceChannel = null;
             changedAnything = true;
         }
+        if (communicationChannel != null) {
+            communicationChannel = null;
+            changedAnything = true;
+        }
+
 
         setLastPlaybackNotification(null);
         return changedAnything;

--- a/src/main/java/net/robinfriedli/botify/boot/Launcher.java
+++ b/src/main/java/net/robinfriedli/botify/boot/Launcher.java
@@ -143,7 +143,7 @@ public class Launcher {
             SecurityManager securityManager = new SecurityManager(guildManager);
 
             CommandListener commandListener = new CommandListener(executionQueueManager, commandManager, guildManager, messageService, sessionFactory, spotifyApiBuilder);
-            GuildJoinListener guildJoinListener = new GuildJoinListener(executionQueueManager, discordBotListAPI, guildManager, jxpBackend, messageService, sessionFactory, spotifyApiBuilder);
+            GuildJoinListener guildJoinListener = new GuildJoinListener(executionQueueManager, discordBotListAPI, guildManager);
             WidgetListener widgetListener = new WidgetListener(guildManager, messageService);
             VoiceChannelListener voiceChannelListener = new VoiceChannelListener(audioManager);
 

--- a/src/main/java/net/robinfriedli/botify/command/commands/AbstractPlayableLoadingCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AbstractPlayableLoadingCommand.java
@@ -60,7 +60,6 @@ public abstract class AbstractPlayableLoadingCommand extends AbstractSourceDecid
     public void doRun() throws Exception {
         AudioManager audioManager = Botify.get().getAudioManager();
         AudioPlayback playback = audioManager.getPlaybackForGuild(getContext().getGuild());
-        playback.setCommunicationChannel(getContext().getChannel());
 
         if (UrlValidator.getInstance().isValid(getCommandInput())) {
             loadUrlItems(audioManager, playback);

--- a/src/main/java/net/robinfriedli/botify/command/widgets/actions/SkipAction.java
+++ b/src/main/java/net/robinfriedli/botify/command/widgets/actions/SkipAction.java
@@ -33,6 +33,7 @@ public class SkipAction extends AbstractWidgetAction {
                 audioManager.startPlayback(guild, voiceState != null ? voiceState.getChannel() : null);
             } else {
                 audioPlayback.stop();
+                queue.reset();
             }
         }
     }

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/ClearAbandonedGuildContextsTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/ClearAbandonedGuildContextsTask.java
@@ -1,0 +1,49 @@
+package net.robinfriedli.botify.cron.tasks;
+
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.robinfriedli.botify.Botify;
+import net.robinfriedli.botify.cron.AbstractCronTask;
+import net.robinfriedli.botify.discord.CommandExecutionQueueManager;
+import net.robinfriedli.botify.discord.GuildContext;
+import net.robinfriedli.botify.discord.GuildManager;
+import net.robinfriedli.botify.listeners.GuildJoinListener;
+import net.robinfriedli.jxp.exec.Invoker;
+import org.quartz.JobExecutionContext;
+
+/**
+ * Task that periodically removes {@link GuildContext} instances belonging to guilds that are no longer associated with
+ * this bot and whose exit was not picked up by the {@link GuildJoinListener}
+ */
+public class ClearAbandonedGuildContextsTask extends AbstractCronTask {
+
+    @Override
+    protected void run(JobExecutionContext jobExecutionContext) {
+        Botify botify = Botify.get();
+        JDA jda = botify.getJda();
+        GuildManager guildManager = botify.getGuildManager();
+        CommandExecutionQueueManager executionQueueManager = botify.getExecutionQueueManager();
+
+        int removedGuilds = 0;
+        for (GuildContext guildContext : Lists.newArrayList(guildManager.getGuildContexts())) {
+            Guild guild = guildContext.getGuild();
+            if (jda.getGuildById(guild.getIdLong()) == null) {
+                guildManager.removeGuild(guild);
+                executionQueueManager.removeGuild(guild);
+                ++removedGuilds;
+            }
+        }
+
+        if (removedGuilds > 0) {
+            LoggerFactory.getLogger(getClass()).info("Destroyed context for " + removedGuilds + " missing guilds");
+        }
+    }
+
+    @Override
+    protected Invoker.Mode getMode() {
+        return Invoker.Mode.create();
+    }
+}

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/PlaybackCleanupTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/PlaybackCleanupTask.java
@@ -2,15 +2,15 @@ package net.robinfriedli.botify.cron.tasks;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Lists;
 import net.dv8tion.jda.api.entities.Guild;
 import net.robinfriedli.botify.Botify;
-import net.robinfriedli.botify.audio.AudioManager;
 import net.robinfriedli.botify.audio.AudioPlayback;
 import net.robinfriedli.botify.cron.AbstractCronTask;
 import net.robinfriedli.botify.discord.GuildContext;
@@ -29,9 +29,8 @@ public class PlaybackCleanupTask extends AbstractCronTask {
     public void run(JobExecutionContext jobExecutionContext) {
         Logger logger = LoggerFactory.getLogger(getClass());
         Botify botify = Botify.get();
-        AudioManager audioManager = botify.getAudioManager();
         GuildManager guildManager = botify.getGuildManager();
-        Collection<GuildContext> guildContexts = guildManager.getGuildContexts();
+        List<GuildContext> guildContexts = Lists.newArrayList(guildManager.getGuildContexts());
 
         int clearedAlone = 0;
         for (GuildContext guildContext : guildContexts) {
@@ -63,7 +62,9 @@ public class PlaybackCleanupTask extends AbstractCronTask {
             }
         }
 
-        logger.info(String.format("Cleared %s stale playbacks and stopped %s lone playbacks", playbacksCleared, clearedAlone));
+        if (clearedAlone > 0 || playbacksCleared > 0) {
+            logger.info(String.format("Cleared %s stale playbacks and stopped %s lone playbacks", playbacksCleared, clearedAlone));
+        }
     }
 
     @Override

--- a/src/main/java/net/robinfriedli/botify/discord/MessageService.java
+++ b/src/main/java/net/robinfriedli/botify/discord/MessageService.java
@@ -265,8 +265,16 @@ public class MessageService {
 
     private TextChannel getTextChannelForGuild(Guild guild) {
         Botify botify = Botify.get();
-        GuildPropertyManager guildPropertyManager = botify.getGuildPropertyManager();
         GuildContext guildContext = botify.getGuildManager().getContextForGuild(guild);
+
+        // check if the guild's playback has a current communication text channel
+        MessageChannel playbackCommunicationChannel = guildContext.getPlayback().getCommunicationChannel();
+        if (playbackCommunicationChannel instanceof TextChannel && ((TextChannel) playbackCommunicationChannel).canTalk()) {
+            return (TextChannel) playbackCommunicationChannel;
+        }
+
+        // fetch the default text channel from the customised property
+        GuildPropertyManager guildPropertyManager = botify.getGuildPropertyManager();
         AbstractGuildProperty defaultTextChannelProperty = guildPropertyManager.getProperty("defaultTextChannelId");
         if (defaultTextChannelProperty != null) {
             String defaultTextChannelId = (String) StaticSessionProvider.invokeWithSession(session -> {
@@ -281,6 +289,7 @@ public class MessageService {
             }
         }
 
+        // use guild default defined by discord
         TextChannel defaultChannel = guild.getDefaultChannel();
         if (defaultChannel != null && defaultChannel.canTalk()) {
             return defaultChannel;

--- a/src/main/java/net/robinfriedli/botify/listeners/GuildJoinListener.java
+++ b/src/main/java/net/robinfriedli/botify/listeners/GuildJoinListener.java
@@ -5,21 +5,14 @@ import java.util.concurrent.Executors;
 
 import javax.annotation.Nullable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.wrapper.spotify.SpotifyApi;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.robinfriedli.botify.discord.CommandExecutionQueueManager;
 import net.robinfriedli.botify.discord.GuildManager;
-import net.robinfriedli.botify.discord.MessageService;
 import net.robinfriedli.botify.exceptions.handlers.LoggingExceptionHandler;
-import net.robinfriedli.jxp.api.JxpBackend;
 import org.discordbots.api.client.DiscordBotListAPI;
-import org.hibernate.SessionFactory;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -32,19 +25,10 @@ public class GuildJoinListener extends ListenerAdapter {
     private final DiscordBotListAPI discordBotListAPI;
     private final ExecutorService guildJoinExecutorService;
     private final GuildManager guildManager;
-    private final JxpBackend jxpBackend;
-    private final Logger logger;
-    private final MessageService messageService;
-    private final SessionFactory sessionFactory;
-    private final SpotifyApi.Builder spotifyApiBuilder;
 
     public GuildJoinListener(CommandExecutionQueueManager executionQueueManager,
                              @Nullable DiscordBotListAPI discordBotListAPI,
-                             GuildManager guildManager,
-                             JxpBackend jxpBackend,
-                             MessageService messageService,
-                             SessionFactory sessionFactory,
-                             SpotifyApi.Builder spotifyApiBuilder) {
+                             GuildManager guildManager) {
         this.executionQueueManager = executionQueueManager;
         this.discordBotListAPI = discordBotListAPI;
         guildJoinExecutorService = Executors.newFixedThreadPool(3, r -> {
@@ -53,11 +37,6 @@ public class GuildJoinListener extends ListenerAdapter {
             return thread;
         });
         this.guildManager = guildManager;
-        this.jxpBackend = jxpBackend;
-        this.messageService = messageService;
-        this.sessionFactory = sessionFactory;
-        this.spotifyApiBuilder = spotifyApiBuilder;
-        logger = LoggerFactory.getLogger(getClass());
     }
 
     @Override


### PR DESCRIPTION
 - create new cron task ClearAbandonedGuildContextsTask to periodically
   remove GuildContext instances belonging to guilds that are no longer
   associated with this bot
   - handles rare cases where a guild exit is not picked up by the
     GuildJoinListener because it was temporarily offline
 - SkipAction: reset queue position when the playback stops after
   skipping the last item in the queue
 - MessageService: consider a guild playback's current communication
   text channel when sending a message to a guild
 - reset the playback's communication channel when clearing the playback
 - remove some unused variables