### PR TITLE
CommandParser: use instance variable instead of static ThreadLocal

### DIFF
--- a/src/main/java/net/robinfriedli/botify/command/parser/ArgumentBuildingMode.java
+++ b/src/main/java/net/robinfriedli/botify/command/parser/ArgumentBuildingMode.java
@@ -38,7 +38,7 @@ public class ArgumentBuildingMode implements CommandParser.Mode {
         this.commandParser = commandParser;
         this.argumentPrefix = argumentPrefix;
         this.isInline = isInline;
-        conceptionIndex = CommandParser.currentPosition.get();
+        conceptionIndex = commandParser.getCurrentPosition();
         argumentBuilder = new StringBuilder();
         argumentValueBuilder = new StringBuilder();
     }

--- a/src/main/java/net/robinfriedli/botify/command/parser/CommandParser.java
+++ b/src/main/java/net/robinfriedli/botify/command/parser/CommandParser.java
@@ -29,7 +29,7 @@ public class CommandParser {
 
     private static final Set<Character> META = ImmutableSet.of(ArgumentPrefixProperty.DEFAULT, '"', '\\', '=', ' ');
 
-    static ThreadLocal<Integer> currentPosition = ThreadLocal.withInitial(() -> 0);
+    private int currentPosition = 0;
 
     private final AbstractCommand command;
     private final char argumentPrefix;
@@ -54,7 +54,7 @@ public class CommandParser {
     public void parse(String input) {
         char[] chars = input.toCharArray();
         for (int i = 0; i < chars.length; i++) {
-            currentPosition.set(i);
+            currentPosition = i;
             char character = chars[i];
             Mode previousMode = currentMode;
             try {
@@ -103,6 +103,10 @@ public class CommandParser {
         }
 
         fireOnParseFinished();
+    }
+
+    public int getCurrentPosition() {
+        return currentPosition;
     }
 
     void fireOnParseFinished() {


### PR DESCRIPTION
 - the position is only used by the ArgumentBuildingMode now, which has
   access to the current CommandParser instance anyway