### PR TITLE
introduce new entity UserPlaybackHistory

### DIFF
--- a/resources/hibernate.cfg.xml
+++ b/resources/hibernate.cfg.xml
@@ -40,5 +40,6 @@
     <mapping class="net.robinfriedli.botify.entities.GrantedRole"/>
     <mapping class="net.robinfriedli.botify.entities.SpotifyRedirectIndex"/>
     <mapping class="net.robinfriedli.botify.entities.CurrentYouTubeQuotaUsage"/>
+    <mapping class="net.robinfriedli.botify.entities.UserPlaybackHistory"/>
   </session-factory>
 </hibernate-configuration>

--- a/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
+++ b/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
@@ -57,7 +57,7 @@ public class QueueIterator extends AudioEventAdapter {
         }
 
         Playable current = queue.getCurrent();
-        audioManager.createHistoryEntry(current, playback.getGuild());
+        audioManager.createHistoryEntry(current, playback.getGuild(), playback.getVoiceChannel());
         if (shouldSendPlaybackNotification()) {
             sendCurrentTrackNotification(current);
         }

--- a/src/main/java/net/robinfriedli/botify/entities/PlaybackHistory.java
+++ b/src/main/java/net/robinfriedli/botify/entities/PlaybackHistory.java
@@ -12,6 +12,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import com.google.api.client.util.Sets;
@@ -47,6 +48,8 @@ public class PlaybackHistory implements Serializable {
     private String guildId;
     @ManyToMany
     private Set<Artist> artists = Sets.newHashSet();
+    @OneToMany(mappedBy = "playbackHistory")
+    private Set<UserPlaybackHistory> userPlaybackHistories = Sets.newHashSet();
 
     public PlaybackHistory() {
     }
@@ -152,4 +155,17 @@ public class PlaybackHistory implements Serializable {
     public void setArtists(Set<Artist> artists) {
         this.artists = artists;
     }
+
+    public Set<UserPlaybackHistory> getUserPlaybackHistories() {
+        return userPlaybackHistories;
+    }
+
+    public void setUserPlaybackHistories(Set<UserPlaybackHistory> userPlaybackHistories) {
+        this.userPlaybackHistories = userPlaybackHistories;
+    }
+
+    public void addUserPlaybackHistory(UserPlaybackHistory userPlaybackHistory) {
+        userPlaybackHistories.add(userPlaybackHistory);
+    }
+
 }

--- a/src/main/java/net/robinfriedli/botify/entities/UserPlaybackHistory.java
+++ b/src/main/java/net/robinfriedli/botify/entities/UserPlaybackHistory.java
@@ -1,0 +1,73 @@
+package net.robinfriedli.botify.entities;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import net.dv8tion.jda.api.entities.User;
+
+/**
+ * Entity that is created for each user currently in the voice channel when creating the {@link PlaybackHistory}
+ */
+@Entity
+@Table(name = "user_playback_history")
+public class UserPlaybackHistory implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pk")
+    private long pk;
+    @Column(name = "user_name")
+    private String userName;
+    @Column(name = "user_id")
+    private String userId;
+    @ManyToOne
+    @JoinColumn(name = "playback_history_pk", referencedColumnName = "pk", foreignKey = @ForeignKey(name = "fk_playback_history"))
+    private PlaybackHistory playbackHistory;
+
+    public UserPlaybackHistory() {
+    }
+
+    public UserPlaybackHistory(User user, PlaybackHistory playbackHistory) {
+        userName = user.getName();
+        userId = user.getId();
+        this.playbackHistory = playbackHistory;
+        playbackHistory.addUserPlaybackHistory(this);
+    }
+
+    public long getPk() {
+        return pk;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public PlaybackHistory getPlaybackHistory() {
+        return playbackHistory;
+    }
+
+    public void setPlaybackHistory(PlaybackHistory playbackHistory) {
+        this.playbackHistory = playbackHistory;
+    }
+}


### PR DESCRIPTION
 - used to relate PlaybackHistory entities to each user currently in the
   voice channel when creating the PlaybackHistory
   - prepares for future track suggestion features and charts expansions