### PR TITLE
add missing return statement in QueueIterator#playNext

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
+++ b/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
@@ -120,7 +120,6 @@ public class QueueIterator extends AudioEventAdapter {
             try {
                 playbackUrl = track.getPlaybackUrl();
             } catch (UnavailableResourceException e) {
-                ++retryCount;
                 iterateQueue(playback, queue, true);
                 return;
             }
@@ -132,6 +131,7 @@ public class QueueIterator extends AudioEventAdapter {
 
                 ++retryCount;
                 iterateQueue(playback, queue, true);
+                return;
             }
         }
         if (result != null) {


### PR DESCRIPTION
 - the playNext call should iterate the queue and immediately return
   on failure or it will call #iterateQueue again at a later point
   which will cause the bot to spam error messages