### PR TITLE
make current youtube quota usage instantly visible across all threads

### DIFF
--- a/resources/xml-contributions/commands.xml
+++ b/resources/xml-contributions/commands.xml
@@ -194,4 +194,6 @@
            description="Deletes data associated with guilds the bot is no longer a part of"/>
   <command identifier="garbage collect" implementation="net.robinfriedli.botify.command.commands.admin.GarbageCollectCommand"
            description="Executes a Java garbage collection to manually clean up memory when convenient"/>
+  <command identifier="youtube quota" implementation="net.robinfriedli.botify.command.commands.admin.YouTubeQuotaCommand"
+           description="Displays the current calculated usage of the daily YouTube API quota."/>
 </commands>

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/ResetOutdatedYouTubeQuotaTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/ResetOutdatedYouTubeQuotaTask.java
@@ -16,6 +16,12 @@ import net.robinfriedli.botify.util.StaticSessionProvider;
  */
 public class ResetOutdatedYouTubeQuotaTask implements StartupTask {
 
+    private final YouTubeService youTubeService;
+
+    public ResetOutdatedYouTubeQuotaTask(YouTubeService youTubeService) {
+        this.youTubeService = youTubeService;
+    }
+
     @Override
     public void perform() {
         StaticSessionProvider.invokeWithSession(session -> {
@@ -29,6 +35,7 @@ public class ResetOutdatedYouTubeQuotaTask implements StartupTask {
                 ZonedDateTime lastUpdated = lastUpdatedNoZone.atZone(ZoneId.systemDefault());
 
                 if (midnight.compareTo(lastUpdated) > 0) {
+                    youTubeService.setAtomicQuotaUsage(0);
                     currentQuotaUsage.setQuota(0);
                 }
             }

--- a/src/main/java/net/robinfriedli/botify/command/commands/admin/YouTubeQuotaCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/admin/YouTubeQuotaCommand.java
@@ -1,0 +1,38 @@
+package net.robinfriedli.botify.command.commands.admin;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.robinfriedli.botify.Botify;
+import net.robinfriedli.botify.audio.youtube.YouTubeService;
+import net.robinfriedli.botify.command.AbstractAdminCommand;
+import net.robinfriedli.botify.command.CommandContext;
+import net.robinfriedli.botify.command.CommandManager;
+import net.robinfriedli.botify.entities.xml.CommandContribution;
+import net.robinfriedli.botify.util.PropertiesLoadingService;
+
+public class YouTubeQuotaCommand extends AbstractAdminCommand {
+
+    public YouTubeQuotaCommand(CommandContribution commandContribution, CommandContext context, CommandManager commandManager, String commandString, String identifier, String description) {
+        super(commandContribution, context, commandManager, commandString, false, identifier, description);
+    }
+
+    @Override
+    public void runAdmin() {
+        YouTubeService youTubeService = Botify.get().getAudioManager().getYouTubeService();
+        int atomic = youTubeService.getAtomicQuotaUsage();
+        int persistent = YouTubeService.getCurrentQuotaUsage(getContext().getSession()).getQuota();
+        int limit = PropertiesLoadingService.requireProperty(Integer.class, "YOUTUBE_API_DAILY_QUOTA");
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.setTitle("YouTube API quota usage");
+        embedBuilder.setDescription("Displays the current approximate usage of the daily YouTube API quota");
+        embedBuilder.addField("Current atomic value", String.valueOf(atomic), true);
+        embedBuilder.addField("Current persistent value", String.valueOf(persistent), true);
+        embedBuilder.addField("Daily limit", String.valueOf(limit), true);
+
+        sendMessage(embedBuilder);
+    }
+
+    @Override
+    public void onSuccess() {
+    }
+}

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/RefreshSpotifyRedirectIndicesTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/RefreshSpotifyRedirectIndicesTask.java
@@ -25,6 +25,7 @@ import net.robinfriedli.botify.audio.youtube.HollowYouTubeVideo;
 import net.robinfriedli.botify.audio.youtube.YouTubeService;
 import net.robinfriedli.botify.cron.AbstractCronTask;
 import net.robinfriedli.botify.entities.SpotifyRedirectIndex;
+import net.robinfriedli.botify.exceptions.CommandRuntimeException;
 import net.robinfriedli.botify.exceptions.UnavailableResourceException;
 import net.robinfriedli.botify.function.modes.HibernateTransactionMode;
 import net.robinfriedli.botify.function.modes.SpotifyAuthorizationMode;
@@ -123,7 +124,11 @@ public class RefreshSpotifyRedirectIndicesTask extends AbstractCronTask {
                 }
 
                 HollowYouTubeVideo hollowYouTubeVideo = new HollowYouTubeVideo(youTubeService, track);
-                youTubeService.redirectSpotify(hollowYouTubeVideo);
+                try {
+                    youTubeService.redirectSpotify(hollowYouTubeVideo);
+                } catch (CommandRuntimeException e) {
+                    throw e.getCause();
+                }
                 if (!hollowYouTubeVideo.isCanceled() && !Strings.isNullOrEmpty(track.getId())) {
                     String videoId = hollowYouTubeVideo.getVideoId();
                     index.setYouTubeId(videoId);

--- a/src/main/java/net/robinfriedli/botify/entities/CurrentYouTubeQuotaUsage.java
+++ b/src/main/java/net/robinfriedli/botify/entities/CurrentYouTubeQuotaUsage.java
@@ -14,7 +14,7 @@ import javax.persistence.Table;
  * Table that holds a single row that describes the current usage of the daily YouTube API quota. This number is a
  * calculated approximate of the actual Quota usage using value from the
  * <a href="https://developers.google.com/youtube/v3/determine_quota_cost">YouTube Data API (v3) - Quota Calculator</a>
- * and is nit guaranteed to represent the actual Quota usage. From Google: "To use the tool, select the appropriate
+ * and is not guaranteed to represent the actual Quota usage. From Google: "To use the tool, select the appropriate
  * resource, method, and part parameter values for your request, and the approximate quota cost will display in the table.
  * Please remember that quota costs can change without warning, and the values shown here may not be exact."
  */


### PR DESCRIPTION
 - when reading the current persistent quota usage from the database,
   make sure to use a fresh Session instance to return the actual state
   from the database and not a cached session state
   - for example, when running the RefreshSpotifyRedirectIndicesTask
     the YoutubeService#getCurrentQuota method used the session of the
     task which always returned the same cached state when called so
     changes to the quota and ultimately reaching the threshold was
     invisible to the task so it never lowered the quota usage
 - additionally store the current quota usage as AtomicInteger to
   ensure atomic incrementation and do not always read the quota from
   the database
 - add new admin command YouTubeQuotaCommand to monitor quota usage
   - displays the current value of the AtomicInteger, the persisted
     quota and the limit
 - RefreshSpotifyRedirectIndicesTask: catch CommandRuntimeExceptions and
   propagate the cause