### PR TITLE
RefreshSpotifyRedirectIndicesTask: use pessimistic locking

### DIFF
--- a/resources/hibernate.cfg.xml
+++ b/resources/hibernate.cfg.xml
@@ -41,5 +41,6 @@
     <mapping class="net.robinfriedli.botify.entities.SpotifyRedirectIndex"/>
     <mapping class="net.robinfriedli.botify.entities.CurrentYouTubeQuotaUsage"/>
     <mapping class="net.robinfriedli.botify.entities.UserPlaybackHistory"/>
+    <mapping class="net.robinfriedli.botify.entities.SpotifyRedirectIndexModificationLock"/>
   </session-factory>
 </hibernate-configuration>

--- a/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndexModificationLock.java
+++ b/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndexModificationLock.java
@@ -1,0 +1,46 @@
+package net.robinfriedli.botify.entities;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import net.robinfriedli.botify.audio.spotify.SpotifyRedirectService;
+import net.robinfriedli.botify.cron.tasks.RefreshSpotifyRedirectIndicesTask;
+
+/**
+ * Creates a lock while running the {@link RefreshSpotifyRedirectIndicesTask} to signal the {@link SpotifyRedirectService}
+ * not to update or delete any {@link SpotifyRedirectIndex} entities
+ */
+@Entity
+@Table(name = "spotify_redirect_index_modification_lock")
+public class SpotifyRedirectIndexModificationLock implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pk")
+    private long pk;
+    @Column(name = "creation_time_stamp")
+    private LocalDateTime creationTimeStamp;
+
+    public long getPk() {
+        return pk;
+    }
+
+    public void setPk(long pk) {
+        this.pk = pk;
+    }
+
+    public LocalDateTime getCreationTimeStamp() {
+        return creationTimeStamp;
+    }
+
+    public void setCreationTimeStamp(LocalDateTime creationTimeStamp) {
+        this.creationTimeStamp = creationTimeStamp;
+    }
+}

--- a/src/main/resources/liquibase/dbchangelog.xml
+++ b/src/main/resources/liquibase/dbchangelog.xml
@@ -38,4 +38,12 @@ See RunLiquibaseUpdateTask
       <column name="quota" value="0"/>
     </insert>
   </changeSet>
+  <changeSet id="delete_existing_spotify_redirect_index_modification_locks-sd23f/1.6.LTS" author="robinfriedli" context="initialvalue" runAlways="true">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <sqlCheck expectedResult="0">select count(*) from spotify_redirect_index_modification_lock</sqlCheck>
+      </not>
+    </preConditions>
+    <delete tableName="spotify_redirect_index_modification_lock"/>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
 - the longer the task runs the higher are the changes a redirect index
   is deleted by the SpotifyRedirectService while the task runs, which
   could cause an OptimisticLockException if the index is one of those
   currently being updated by the task
   - the RefreshSpotifyRedirectIndicesTask now loads the indices with
     LockOption PESSIMISTIC_WRITE
   - introduce new table SpotifyRedirectIndexModificationLock that is
     created when the RefreshSpotifyRedirectIndicesTask starts and
     deleted when it ends
     - while a SpotifyRedirectIndexModificationLock the
       SpotifyRedirectService may not delete or update any
       SpotifyRedirectIndices
     - create a changeset that always runs on startup and deletes all
       existing SpotifyRedirectIndexModificationLocks for if the bot was
       terminated after a RefreshSpotifyRedirectIndicesTask started and
       before it ended