### PR TITLE
add last_used attribute to SpotifyRedirectService

### DIFF
--- a/src/main/java/net/robinfriedli/botify/cron/tasks/RefreshSpotifyRedirectIndicesTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/RefreshSpotifyRedirectIndicesTask.java
@@ -72,13 +72,13 @@ public class RefreshSpotifyRedirectIndicesTask extends AbstractCronTask {
             SpotifyTrackBulkLoadingService spotifyTrackBulkLoadingService = new SpotifyTrackBulkLoadingService(spotifyApi, true);
 
             LocalDate currentDate = LocalDate.now();
-            LocalDate date2WeeksAgo = currentDate.minusDays(28);
+            LocalDate date4WeeksAgo = currentDate.minusDays(28);
 
             StaticSessionProvider.invokeWithSession(session -> {
                 CriteriaBuilder cb = session.getCriteriaBuilder();
                 CriteriaQuery<SpotifyRedirectIndex> query = cb.createQuery(SpotifyRedirectIndex.class);
                 Root<SpotifyRedirectIndex> root = query.from(SpotifyRedirectIndex.class);
-                query.where(cb.lessThan(root.get("lastUpdated"), date2WeeksAgo));
+                query.where(cb.lessThan(root.get("lastUpdated"), date4WeeksAgo));
                 query.orderBy(cb.asc(root.get("lastUpdated")));
                 List<SpotifyRedirectIndex> indices = session.createQuery(query).setLockOptions(new LockOptions(LockMode.PESSIMISTIC_WRITE)).getResultList();
 
@@ -149,18 +149,23 @@ public class RefreshSpotifyRedirectIndicesTask extends AbstractCronTask {
                     return;
                 }
 
-                HollowYouTubeVideo hollowYouTubeVideo = new HollowYouTubeVideo(youTubeService, track);
-                try {
-                    youTubeService.redirectSpotify(hollowYouTubeVideo);
-                } catch (CommandRuntimeException e) {
-                    throw e.getCause();
-                }
-                if (!hollowYouTubeVideo.isCanceled() && !Strings.isNullOrEmpty(track.getId())) {
-                    String videoId = hollowYouTubeVideo.getVideoId();
-                    index.setYouTubeId(videoId);
-                    index.setLastUpdated(LocalDate.now());
-                } else {
+                LocalDate date2WeeksAgo = LocalDate.now().minusDays(14);
+                if (index.getLastUsed().compareTo(date2WeeksAgo) < 0) {
                     session.delete(index);
+                } else {
+                    HollowYouTubeVideo hollowYouTubeVideo = new HollowYouTubeVideo(youTubeService, track);
+                    try {
+                        youTubeService.redirectSpotify(hollowYouTubeVideo);
+                    } catch (CommandRuntimeException e) {
+                        throw e.getCause();
+                    }
+                    if (!hollowYouTubeVideo.isCanceled() && !Strings.isNullOrEmpty(track.getId())) {
+                        String videoId = hollowYouTubeVideo.getVideoId();
+                        index.setYouTubeId(videoId);
+                        index.setLastUpdated(LocalDate.now());
+                    } else {
+                        session.delete(index);
+                    }
                 }
             } catch (UnavailableResourceException e) {
                 logger.warn("Tried creating a SpotifyRedirectIndex for an unavailable Video for track id " + track.getId());

--- a/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndex.java
+++ b/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndex.java
@@ -36,6 +36,8 @@ public class SpotifyRedirectIndex implements Serializable {
     private String youTubeId;
     @Column(name = "last_updated")
     private LocalDate lastUpdated;
+    @Column(name = "last_used")
+    private LocalDate lastUsed;
 
     public SpotifyRedirectIndex() {
     }
@@ -89,4 +91,11 @@ public class SpotifyRedirectIndex implements Serializable {
         this.lastUpdated = lastUpdated;
     }
 
+    public LocalDate getLastUsed() {
+        return lastUsed;
+    }
+
+    public void setLastUsed(LocalDate lastUsed) {
+        this.lastUsed = lastUsed;
+    }
 }

--- a/src/main/resources/liquibase/dbchangelog.xml
+++ b/src/main/resources/liquibase/dbchangelog.xml
@@ -46,4 +46,13 @@ See RunLiquibaseUpdateTask
     </preConditions>
     <delete tableName="spotify_redirect_index_modification_lock"/>
   </changeSet>
+  <changeSet id="set_last_used_now-DF4c3/1.6.LTS" author="robinfriedli" context="initialvalue">
+    <preConditions>
+      <columnExists tableName="spotify_redirect_index" columnName="last_used"/>
+    </preConditions>
+    <update tableName="spotify_redirect_index">
+      <column name="last_used" valueDate="NOW()"/>
+      <where>last_used is null</where>
+    </update>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
 - delete SpotifyRedirectService entities that haven't been used in 14
   days instead of refreshing them