### PR TITLE
enforce thread safety when using CommandContext and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,28 +55,28 @@
     <dependency>
       <groupId>com.sedmelluq</groupId>
       <artifactId>lavaplayer</artifactId>
-      <version>1.3.38</version>
+      <version>1.3.47</version>
     </dependency>
     <dependency>
       <groupId>com.sedmelluq</groupId>
       <artifactId>lavaplayer-ext-youtube-rotator</artifactId>
-      <version>0.2.1</version>
+      <version>0.2.3</version>
     </dependency>
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>4.1.1_123</version>
+      <version>4.1.1_142</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>net.robinfriedli.JXP</groupId>
+      <groupId>net.robinfriedli</groupId>
       <artifactId>JXP</artifactId>
-      <version>1.2.1</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
-      <groupId>net.robinfriedli.StringList</groupId>
+      <groupId>net.robinfriedli</groupId>
       <artifactId>StringList</artifactId>
-      <version>1.4</version>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>commons-validator</groupId>

--- a/src/main/java/net/robinfriedli/botify/audio/PlayableFactory.java
+++ b/src/main/java/net/robinfriedli/botify/audio/PlayableFactory.java
@@ -40,7 +40,6 @@ import net.robinfriedli.botify.function.CheckedFunction;
 import net.robinfriedli.botify.function.SpotifyInvoker;
 import net.robinfriedli.botify.util.StaticSessionProvider;
 import net.robinfriedli.stringlist.StringList;
-import net.robinfriedli.stringlist.StringListImpl;
 import org.hibernate.Session;
 
 /**
@@ -261,7 +260,7 @@ public class PlayableFactory {
             String[] parts = uri.getPath().split("/");
             return youTubeService.requireVideoForId(parts[parts.length - 1]);
         } else if (uri.getHost().equals("open.spotify.com")) {
-            StringList pathFragments = StringListImpl.create(uri.getPath(), "/");
+            StringList pathFragments = StringList.createWithRegex(uri.getPath(), "/");
             if (pathFragments.contains("track")) {
                 String trackId = pathFragments.tryGet(pathFragments.indexOf("track") + 1);
                 if (trackId == null) {
@@ -362,7 +361,7 @@ public class PlayableFactory {
     }
 
     private List<Playable> createPlayablesFromSpotifyUrl(URI uri, SpotifyApi spotifyApi, boolean redirectSpotify, boolean mayInterrupt) {
-        StringList pathFragments = StringListImpl.create(uri.getPath(), "/");
+        StringList pathFragments = StringList.createWithRegex(uri.getPath(), "/");
         SpotifyService spotifyService = new SpotifyService(spotifyApi);
         if (pathFragments.contains("playlist")) {
             String playlistId = pathFragments.tryGet(pathFragments.indexOf("playlist") + 1);

--- a/src/main/java/net/robinfriedli/botify/audio/spotify/SpotifyRedirectService.java
+++ b/src/main/java/net/robinfriedli/botify/audio/spotify/SpotifyRedirectService.java
@@ -21,7 +21,7 @@ import net.robinfriedli.botify.entities.SpotifyRedirectIndexModificationLock;
 import net.robinfriedli.botify.exceptions.UnavailableResourceException;
 import net.robinfriedli.botify.function.HibernateInvoker;
 import net.robinfriedli.botify.util.StaticSessionProvider;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Session;
 
 import static net.robinfriedli.botify.entities.SpotifyRedirectIndex.*;
@@ -66,7 +66,7 @@ public class SpotifyRedirectService {
                     throw new RuntimeException(e);
                 }
                 String name = spotifyTrack.getName();
-                String artistString = StringListImpl.create(spotifyTrack.getArtists(), ArtistSimplified::getName).toSeparatedString(", ");
+                String artistString = StringList.create(spotifyTrack.getArtists(), ArtistSimplified::getName).toSeparatedString(", ");
                 String title = String.format("%s by %s", name, artistString);
                 youTubeVideo.setTitle(title);
 

--- a/src/main/java/net/robinfriedli/botify/audio/spotify/SpotifyTrackResultHandler.java
+++ b/src/main/java/net/robinfriedli/botify/audio/spotify/SpotifyTrackResultHandler.java
@@ -17,7 +17,7 @@ import com.google.common.collect.Multimap;
 import com.wrapper.spotify.model_objects.specification.ArtistSimplified;
 import com.wrapper.spotify.model_objects.specification.Track;
 import net.dv8tion.jda.api.entities.Guild;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 
@@ -84,7 +84,7 @@ public class SpotifyTrackResultHandler {
             .flatMap(track -> Arrays.stream(track.getArtists()))
             .map(ArtistSimplified::getId)
             .collect(Collectors.toSet());
-        String artistIdString = StringListImpl.create(artistIds).applyForEach(s -> s = "'" + s + "'").toSeparatedString(", ");
+        String artistIdString = StringList.create(artistIds).applyForEach(s -> s = "'" + s + "'").toSeparatedString(", ");
 
         @SuppressWarnings("unchecked")
         Query<Object[]> artistPopularityQuery = session.createSQLQuery("select a.id, count(*) from playback_history_artist as p " +

--- a/src/main/java/net/robinfriedli/botify/audio/spotify/TrackWrapper.java
+++ b/src/main/java/net/robinfriedli/botify/audio/spotify/TrackWrapper.java
@@ -16,7 +16,7 @@ import net.robinfriedli.botify.audio.youtube.YouTubeService;
 import net.robinfriedli.botify.entities.Playlist;
 import net.robinfriedli.botify.entities.PlaylistItem;
 import net.robinfriedli.botify.entities.Song;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Session;
 
 /**
@@ -45,7 +45,7 @@ public class TrackWrapper extends AbstractSoftCachedPlayable implements Playable
     @Override
     public String getDisplay() {
         String name = track.getName();
-        String artistString = StringListImpl.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", ");
+        String artistString = StringList.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", ");
         return String.format("%s by %s", name, artistString);
     }
 

--- a/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeService.java
+++ b/src/main/java/net/robinfriedli/botify/audio/youtube/YouTubeService.java
@@ -51,7 +51,6 @@ import net.robinfriedli.botify.exceptions.UnavailableResourceException;
 import net.robinfriedli.botify.exceptions.handlers.LoggingExceptionHandler;
 import net.robinfriedli.botify.util.StaticSessionProvider;
 import net.robinfriedli.stringlist.StringList;
-import net.robinfriedli.stringlist.StringListImpl;
 import org.hibernate.Session;
 
 /**
@@ -116,7 +115,7 @@ public class YouTubeService {
             throw new IllegalArgumentException(youTubeVideo.toString() + " is not a placeholder for a redirected Spotify Track");
         }
 
-        StringList artists = StringListImpl.create(spotifyTrack.getArtists(), ArtistSimplified::getName);
+        StringList artists = StringList.create(spotifyTrack.getArtists(), ArtistSimplified::getName);
         String searchTerm = spotifyTrack.getName() + " " + artists.toSeparatedString(" ");
         List<String> videoIds;
 
@@ -228,7 +227,7 @@ public class YouTubeService {
         String videoTitle = video.getSnippet().getTitle().toLowerCase();
         ArtistSimplified[] artists = track.getArtists();
         String firstArtist = artists.length > 0 ? artists[0].getName().toLowerCase() : "";
-        StringList artistNames = StringListImpl.create(artists, ArtistSimplified::getName);
+        StringList artistNames = StringList.create(artists, ArtistSimplified::getName);
         String artistString = artistNames
             .toSeparatedString(", ")
             .toLowerCase();

--- a/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
@@ -37,7 +37,6 @@ import net.robinfriedli.botify.login.Login;
 import net.robinfriedli.botify.util.Util;
 import net.robinfriedli.jxp.exec.modes.SynchronisationMode;
 import net.robinfriedli.stringlist.StringList;
-import net.robinfriedli.stringlist.StringListImpl;
 
 /**
  * Abstract class to extend for any text based command implementation. Implementations need to be added and configured in the
@@ -57,7 +56,7 @@ public abstract class AbstractCommand implements Command {
     private final String identifier;
     private final String description;
     private final Category category;
-    private boolean requiresInput;
+    private final boolean requiresInput;
     private String commandInput;
     // used to prevent onSuccess being called when no exception has been thrown but the command failed anyway
     private boolean isFailed;
@@ -345,7 +344,7 @@ public abstract class AbstractCommand implements Command {
 
     @Deprecated
     protected Pair<String, String> splitInlineArgument(String part, String argument) {
-        StringList words = StringListImpl.create(part, " ");
+        StringList words = StringList.createWithRegex(part, " ");
 
         List<Integer> positions = words.findPositionsOf("$" + argument, true);
         if (positions.isEmpty()) {
@@ -437,7 +436,7 @@ public abstract class AbstractCommand implements Command {
      */
     @Deprecated
     private void processCommand(String commandString) {
-        StringList words = StringListImpl.separateString(commandString, " ");
+        StringList words = StringList.separateString(commandString, " ");
 
         int commandBodyIndex = 0;
         for (String word : words) {

--- a/src/main/java/net/robinfriedli/botify/command/ClientQuestionEvent.java
+++ b/src/main/java/net/robinfriedli/botify/command/ClientQuestionEvent.java
@@ -27,12 +27,11 @@ public class ClientQuestionEvent {
 
     private final AbstractCommand sourceCommand;
     private final Timer destructionTimer;
-    private CompletableFuture<Message> questionMessage;
-
     /**
      * the available answers for the user mapped to the option they represent
      */
-    private Map<String, Option> options = new LinkedHashMap<>();
+    private final Map<String, Option> options = new LinkedHashMap<>();
+    private CompletableFuture<Message> questionMessage;
 
     public ClientQuestionEvent(AbstractCommand sourceCommand) {
         this.sourceCommand = sourceCommand;

--- a/src/main/java/net/robinfriedli/botify/command/commands/AbstractPlayableLoadingCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/AbstractPlayableLoadingCommand.java
@@ -31,7 +31,7 @@ import net.robinfriedli.botify.exceptions.NoResultsFoundException;
 import net.robinfriedli.botify.exceptions.NoSpotifyResultsFoundException;
 import net.robinfriedli.botify.exceptions.UnavailableResourceException;
 import net.robinfriedli.botify.util.SearchEngine;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 
 public abstract class AbstractPlayableLoadingCommand extends AbstractSourceDecidingCommand {
 
@@ -204,7 +204,7 @@ public abstract class AbstractPlayableLoadingCommand extends AbstractSourceDecid
         } else if (albums.isEmpty()) {
             throw new NoSpotifyResultsFoundException(String.format("No albums found for '%s'", getCommandInput()));
         } else {
-            askQuestion(albums, AlbumSimplified::getName, album -> StringListImpl.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "));
+            askQuestion(albums, AlbumSimplified::getName, album -> StringList.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "));
         }
     }
 
@@ -225,7 +225,7 @@ public abstract class AbstractPlayableLoadingCommand extends AbstractSourceDecid
         } else {
             if (argumentSet("select")) {
                 askQuestion(found, track -> {
-                    String artistString = StringListImpl.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", ");
+                    String artistString = StringList.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", ");
                     return String.format("%s by %s", track.getName(), artistString);
                 }, track -> track.getAlbum().getName());
             } else {

--- a/src/main/java/net/robinfriedli/botify/command/commands/HelpCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/HelpCommand.java
@@ -21,7 +21,7 @@ import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.jxp.api.XmlElement;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 
 import static net.robinfriedli.jxp.queries.Conditions.*;
 
@@ -66,7 +66,7 @@ public class HelpCommand extends AbstractCommand {
                 String text;
                 List<Role> roles = accessConfiguration.getRoles(guild);
                 if (!roles.isEmpty()) {
-                    text = StringListImpl.create(roles, Role::getName).toSeparatedString(", ");
+                    text = StringList.create(roles, Role::getName).toSeparatedString(", ");
                 } else {
                     text = "Guild owner only";
                 }

--- a/src/main/java/net/robinfriedli/botify/command/commands/PermissionCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PermissionCommand.java
@@ -20,7 +20,7 @@ import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.botify.util.Table2;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Session;
 
 public class PermissionCommand extends AbstractCommand {
@@ -65,7 +65,7 @@ public class PermissionCommand extends AbstractCommand {
                 if (roles.isEmpty()) {
                     return "Guild owner and administrator roles only";
                 } else {
-                    return StringListImpl.create(roles, Role::getName).toSeparatedString(", ");
+                    return StringList.create(roles, Role::getName).toSeparatedString(", ");
                 }
             } else {
                 return "Available to everyone";

--- a/src/main/java/net/robinfriedli/botify/command/commands/PrefixCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PrefixCommand.java
@@ -1,10 +1,8 @@
 package net.robinfriedli.botify.command.commands;
 
-import net.robinfriedli.botify.Botify;
 import net.robinfriedli.botify.command.AbstractCommand;
 import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
-import net.robinfriedli.botify.discord.GuildManager;
 import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 
@@ -16,8 +14,6 @@ public class PrefixCommand extends AbstractCommand {
 
     @Override
     public void doRun() {
-        GuildManager guildManager = Botify.get().getGuildManager();
-
         if (getCommandInput().length() < 1 || getCommandInput().length() > 5) {
             throw new InvalidCommandException("Length should be 1 - 5 characters");
         }

--- a/src/main/java/net/robinfriedli/botify/command/commands/RemoveCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/RemoveCommand.java
@@ -14,7 +14,6 @@ import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.botify.exceptions.NoResultsFoundException;
 import net.robinfriedli.botify.util.SearchEngine;
 import net.robinfriedli.stringlist.StringList;
-import net.robinfriedli.stringlist.StringListImpl;
 import org.hibernate.Session;
 
 import static java.lang.String.*;
@@ -39,7 +38,7 @@ public class RemoveCommand extends AbstractCommand {
         }
 
         if (argumentSet("index")) {
-            StringList indices = StringListImpl.create(getCommandInput(), "-");
+            StringList indices = StringList.createWithRegex(getCommandInput(), "-");
             if (indices.size() == 1 || indices.size() == 2) {
                 indices.applyForEach(String::trim);
                 if (indices.size() == 1) {

--- a/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/SearchCommand.java
@@ -32,7 +32,7 @@ import net.robinfriedli.botify.util.PropertiesLoadingService;
 import net.robinfriedli.botify.util.SearchEngine;
 import net.robinfriedli.botify.util.Table2;
 import net.robinfriedli.botify.util.Util;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Session;
 
 public class SearchCommand extends AbstractSourceDecidingCommand {
@@ -83,7 +83,7 @@ public class SearchCommand extends AbstractSourceDecidingCommand {
                 embedBuilder,
                 found,
                 track -> track.getName() + " - " + track.getAlbum().getName() + " - " +
-                    StringListImpl.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", "),
+                    StringList.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", "),
                 "Track - Album - Artist"
             );
 
@@ -264,13 +264,13 @@ public class SearchCommand extends AbstractSourceDecidingCommand {
                 tracks,
                 album.getName(),
                 null,
-                StringListImpl.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "),
+                StringList.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "),
                 "album/" + album.getId()
             );
         } else if (albums.isEmpty()) {
             throw new NoSpotifyResultsFoundException(String.format("No album found for '%s'", getCommandInput()));
         } else {
-            askQuestion(albums, AlbumSimplified::getName, album -> StringListImpl.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "));
+            askQuestion(albums, AlbumSimplified::getName, album -> StringList.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "));
         }
     }
 
@@ -303,7 +303,7 @@ public class SearchCommand extends AbstractSourceDecidingCommand {
                 embedBuilder,
                 tracks.size() > 5 ? tracks.subList(0, 5) : tracks,
                 track -> track.getName() + " - " +
-                    StringListImpl.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", ") + " - " +
+                    StringList.create(track.getArtists(), ArtistSimplified::getName).toSeparatedString(", ") + " - " +
                     Util.normalizeMillis(track.getDurationMs() != null ? track.getDurationMs() : 0),
                 "Track - Artist - Duration"
             );
@@ -336,7 +336,7 @@ public class SearchCommand extends AbstractSourceDecidingCommand {
             listTracks(tracks,
                 album.getName(),
                 null,
-                StringListImpl.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "),
+                StringList.create(album.getArtists(), ArtistSimplified::getName).toSeparatedString(", "),
                 "album/" + album.getId());
         }
     }

--- a/src/main/java/net/robinfriedli/botify/command/commands/admin/UpdateCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/admin/UpdateCommand.java
@@ -16,7 +16,6 @@ import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
 import net.robinfriedli.botify.entities.xml.CommandContribution;
 import net.robinfriedli.stringlist.StringList;
-import net.robinfriedli.stringlist.StringListImpl;
 
 public class UpdateCommand extends AbstractAdminCommand {
 
@@ -57,7 +56,7 @@ public class UpdateCommand extends AbstractAdminCommand {
 
     private String getInputStreamString(InputStream inputStream) throws IOException {
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-        StringList lineList = StringListImpl.create();
+        StringList lineList = StringList.create();
         String s;
         while ((s = bufferedReader.readLine()) != null) {
             lineList.add(s);

--- a/src/main/java/net/robinfriedli/botify/command/parser/ArgumentBuildingMode.java
+++ b/src/main/java/net/robinfriedli/botify/command/parser/ArgumentBuildingMode.java
@@ -24,8 +24,8 @@ public class ArgumentBuildingMode implements CommandParser.Mode {
     private final boolean isInline;
     private final int conceptionIndex;
 
-    private StringBuilder argumentBuilder;
-    private StringBuilder argumentValueBuilder;
+    private final StringBuilder argumentBuilder;
+    private final StringBuilder argumentValueBuilder;
 
     private boolean isRecodingValue;
 

--- a/src/main/java/net/robinfriedli/botify/command/parser/CommandInputBuildingMode.java
+++ b/src/main/java/net/robinfriedli/botify/command/parser/CommandInputBuildingMode.java
@@ -12,7 +12,7 @@ public class CommandInputBuildingMode implements CommandParser.Mode {
     private final AbstractCommand command;
     private final CommandParser commandParser;
     private final char argumentPrefix;
-    private StringBuilder commandInputBuilder;
+    private final StringBuilder commandInputBuilder;
     private char lastChar;
 
     public CommandInputBuildingMode(AbstractCommand command, CommandParser commandParser, char argumentPrefix) {

--- a/src/main/java/net/robinfriedli/botify/discord/GuildManager.java
+++ b/src/main/java/net/robinfriedli/botify/discord/GuildManager.java
@@ -196,7 +196,7 @@ public class GuildManager {
 
     private GuildContext initializeGuild(Guild guild) {
         synchronized (guild) {
-            return StaticSessionProvider.invokeWithSession(session -> {
+            return StaticSessionProvider.invokeWithoutInterceptors(session -> {
                 AudioPlayer player = audioManager.getPlayerManager().createPlayer();
 
                 Optional<Long> existingSpecification = session.createQuery("select pk from " + GuildSpecification.class.getName()
@@ -241,6 +241,7 @@ public class GuildManager {
 
         SessionFactory sessionFactory = StaticSessionProvider.getSessionFactory();
         SpotifyApi.Builder spotifyApiBuilder = botify.getSpotifyApiBuilder();
+        InterceptorChain.INTERCEPTORS_MUTED.set(false);
         try (Session session = sessionFactory.withOptions().interceptor(InterceptorChain.of(
             PlaylistItemTimestampListener.class, VerifyPlaylistListener.class)).openSession()) {
             String playlistsPath = PropertiesLoadingService.requireProperty("PLAYLISTS_PATH");
@@ -271,6 +272,8 @@ public class GuildManager {
                 }
                 session.getTransaction().commit();
             }
+        } finally {
+            InterceptorChain.INTERCEPTORS_MUTED.set(true);
         }
     }
 

--- a/src/main/java/net/robinfriedli/botify/discord/MessageService.java
+++ b/src/main/java/net/robinfriedli/botify/discord/MessageService.java
@@ -40,7 +40,6 @@ import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.util.PropertiesLoadingService;
 import net.robinfriedli.botify.util.StaticSessionProvider;
 import net.robinfriedli.stringlist.StringList;
-import net.robinfriedli.stringlist.StringListImpl;
 import org.hibernate.Session;
 
 public class MessageService {
@@ -338,7 +337,7 @@ public class MessageService {
 
     private List<String> separateMessage(String message) {
         List<String> outputParts = Lists.newArrayList();
-        StringList paragraphs = StringListImpl.separateString(message, "\n");
+        StringList paragraphs = StringList.separateString(message, "\n");
 
         for (int i = 0; i < paragraphs.size(); i++) {
             String paragraph = paragraphs.get(i);
@@ -350,19 +349,19 @@ public class MessageService {
                 }
             } else {
                 // if the paragraph is too long separate into sentences
-                StringList sentences = StringListImpl.separateString(paragraph, "\\. ");
+                StringList sentences = StringList.separateString(paragraph, "\\. ");
                 for (String sentence : sentences) {
                     if (sentence.length() < limit) {
                         fillPart(outputParts, sentence);
                     } else {
                         // if the sentence is too long split into words
-                        StringList words = StringListImpl.separateString(sentence, " ");
+                        StringList words = StringList.separateString(sentence, " ");
 
                         for (String word : words) {
                             if (word.length() < limit) {
                                 fillPart(outputParts, word);
                             } else {
-                                StringList chars = StringListImpl.charsToList(word);
+                                StringList chars = StringList.splitChars(word);
                                 for (String charString : chars) {
                                     fillPart(outputParts, charString);
                                 }

--- a/src/main/java/net/robinfriedli/botify/entities/AccessConfiguration.java
+++ b/src/main/java/net/robinfriedli/botify/entities/AccessConfiguration.java
@@ -34,15 +34,15 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class AccessConfiguration implements Serializable {
 
+    @OneToMany(mappedBy = "accessConfiguration", fetch = FetchType.EAGER)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    private final Set<GrantedRole> roles = Sets.newHashSet();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "pk")
     private long pk;
     @Column(name = "command_identifier", nullable = false)
     private String commandIdentifier;
-    @OneToMany(mappedBy = "accessConfiguration", fetch = FetchType.EAGER)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-    private Set<GrantedRole> roles = Sets.newHashSet();
     @ManyToOne
     @JoinColumn(name = "guild_specification_pk", referencedColumnName = "pk", foreignKey = @ForeignKey(name = "fk_guild_specification"))
     private GuildSpecification guildSpecification;

--- a/src/main/java/net/robinfriedli/botify/entities/GuildSpecification.java
+++ b/src/main/java/net/robinfriedli/botify/entities/GuildSpecification.java
@@ -26,6 +26,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class GuildSpecification implements Serializable {
 
+    @OneToMany(mappedBy = "guildSpecification")
+    private final Set<AccessConfiguration> accessConfigurations = Sets.newHashSet();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "pk")
@@ -54,8 +56,6 @@ public class GuildSpecification implements Serializable {
     private Integer tempMessageTimeout;
     @Column(name = "default_text_channel_id")
     private String defaultTextChannelId;
-    @OneToMany(mappedBy = "guildSpecification")
-    private Set<AccessConfiguration> accessConfigurations = Sets.newHashSet();
 
     public GuildSpecification() {
     }

--- a/src/main/java/net/robinfriedli/botify/entities/Song.java
+++ b/src/main/java/net/robinfriedli/botify/entities/Song.java
@@ -20,7 +20,7 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.specification.ArtistSimplified;
 import com.wrapper.spotify.model_objects.specification.Track;
 import net.dv8tion.jda.api.entities.User;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 
@@ -82,7 +82,7 @@ public class Song extends PlaylistItem {
 
     @Override
     public String display() {
-        String artistString = StringListImpl.create(artists, Artist::getName).toSeparatedString(", ");
+        String artistString = StringList.create(artists, Artist::getName).toSeparatedString(", ");
         return name + " by " + artistString;
     }
 

--- a/src/main/java/net/robinfriedli/botify/entities/xml/CommandContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/CommandContribution.java
@@ -2,7 +2,6 @@ package net.robinfriedli.botify.entities.xml;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -11,7 +10,7 @@ import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.CommandManager;
 import net.robinfriedli.botify.exceptions.InvalidCommandException;
 import net.robinfriedli.jxp.api.AbstractXmlElement;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -19,14 +18,8 @@ public class CommandContribution extends AbstractXmlElement {
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public CommandContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public CommandContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public CommandContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable

--- a/src/main/java/net/robinfriedli/botify/entities/xml/CommandInterceptorContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/CommandInterceptorContribution.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import net.robinfriedli.botify.command.interceptor.AbstractChainableCommandInterceptor;
 import net.robinfriedli.jxp.api.AbstractXmlElement;
 import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -25,14 +26,8 @@ public class CommandInterceptorContribution extends AbstractXmlElement {
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public CommandInterceptorContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public CommandInterceptorContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public CommandInterceptorContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable

--- a/src/main/java/net/robinfriedli/botify/entities/xml/CronJobContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/CronJobContribution.java
@@ -1,13 +1,12 @@
 package net.robinfriedli.botify.entities.xml;
 
 import java.time.ZoneId;
-import java.util.List;
 import java.util.TimeZone;
 
 import javax.annotation.Nonnull;
 
 import net.robinfriedli.botify.cron.AbstractCronTask;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -15,14 +14,8 @@ public class CronJobContribution extends GenericClassContribution<AbstractCronTa
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public CronJobContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public CronJobContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public CronJobContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Override

--- a/src/main/java/net/robinfriedli/botify/entities/xml/EmbedDocumentContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/EmbedDocumentContribution.java
@@ -1,12 +1,11 @@
 package net.robinfriedli.botify.entities.xml;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.robinfriedli.jxp.api.AbstractXmlElement;
 import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -14,14 +13,8 @@ public class EmbedDocumentContribution extends AbstractXmlElement {
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public EmbedDocumentContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public EmbedDocumentContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public EmbedDocumentContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable

--- a/src/main/java/net/robinfriedli/botify/entities/xml/GenericClassContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/GenericClassContribution.java
@@ -2,11 +2,10 @@ package net.robinfriedli.botify.entities.xml;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
 import net.robinfriedli.botify.util.Cache;
 import net.robinfriedli.jxp.api.AbstractXmlElement;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -15,14 +14,8 @@ public abstract class GenericClassContribution<E> extends AbstractXmlElement {
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public GenericClassContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public GenericClassContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public GenericClassContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/robinfriedli/botify/entities/xml/GuildPropertyContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/GuildPropertyContribution.java
@@ -1,11 +1,9 @@
 package net.robinfriedli.botify.entities.xml;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
 
 import net.robinfriedli.botify.discord.property.AbstractGuildProperty;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -13,14 +11,8 @@ public class GuildPropertyContribution extends GenericClassContribution<Abstract
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public GuildPropertyContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public GuildPropertyContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public GuildPropertyContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable

--- a/src/main/java/net/robinfriedli/botify/entities/xml/HttpHandlerContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/HttpHandlerContribution.java
@@ -1,11 +1,9 @@
 package net.robinfriedli.botify.entities.xml;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
 
 import com.sun.net.httpserver.HttpHandler;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -13,14 +11,8 @@ public class HttpHandlerContribution extends GenericClassContribution<HttpHandle
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public HttpHandlerContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public HttpHandlerContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public HttpHandlerContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable

--- a/src/main/java/net/robinfriedli/botify/entities/xml/StartupTaskContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/StartupTaskContribution.java
@@ -1,11 +1,9 @@
 package net.robinfriedli.botify.entities.xml;
 
-import java.util.List;
-
 import javax.annotation.Nullable;
 
 import net.robinfriedli.botify.boot.StartupTask;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -13,14 +11,8 @@ public class StartupTaskContribution extends GenericClassContribution<StartupTas
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public StartupTaskContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public StartupTaskContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public StartupTaskContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable

--- a/src/main/java/net/robinfriedli/botify/entities/xml/Version.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/Version.java
@@ -6,19 +6,15 @@ import javax.annotation.Nullable;
 
 import net.robinfriedli.botify.boot.VersionManager;
 import net.robinfriedli.jxp.api.AbstractXmlElement;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Element;
 
 public class Version extends AbstractXmlElement implements Comparable<Version> {
 
-    public Version(Element element, Context context) {
-        super(element, context);
-    }
-
-    public Version(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public Version(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable
@@ -55,14 +51,8 @@ public class Version extends AbstractXmlElement implements Comparable<Version> {
 
         // invoked by JXP
         @SuppressWarnings("unused")
-        public Feature(Element element, Context context) {
-            super(element, context);
-        }
-
-        // invoked by JXP
-        @SuppressWarnings("unused")
-        public Feature(Element element, List<XmlElement> subElements, Context context) {
-            super(element, subElements, context);
+        public Feature(Element element, NodeList childNodes, Context context) {
+            super(element, childNodes, context);
         }
 
         @Nullable

--- a/src/main/java/net/robinfriedli/botify/entities/xml/WidgetContribution.java
+++ b/src/main/java/net/robinfriedli/botify/entities/xml/WidgetContribution.java
@@ -2,7 +2,6 @@ package net.robinfriedli.botify.entities.xml;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -10,7 +9,7 @@ import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEve
 import net.robinfriedli.botify.command.AbstractWidget;
 import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.command.widgets.AbstractWidgetAction;
-import net.robinfriedli.jxp.api.XmlElement;
+import net.robinfriedli.jxp.collections.NodeList;
 import net.robinfriedli.jxp.persist.Context;
 import org.w3c.dom.Element;
 
@@ -18,14 +17,8 @@ public class WidgetContribution extends GenericClassContribution<AbstractWidget>
 
     // invoked by JXP
     @SuppressWarnings("unused")
-    public WidgetContribution(Element element, Context context) {
-        super(element, context);
-    }
-
-    // invoked by JXP
-    @SuppressWarnings("unused")
-    public WidgetContribution(Element element, List<XmlElement> subElements, Context context) {
-        super(element, subElements, context);
+    public WidgetContribution(Element element, NodeList childNodes, Context context) {
+        super(element, childNodes, context);
     }
 
     @Nullable
@@ -38,14 +31,8 @@ public class WidgetContribution extends GenericClassContribution<AbstractWidget>
 
         // invoked by JXP
         @SuppressWarnings("unused")
-        public WidgetActionContribution(Element element, Context context) {
-            super(element, context);
-        }
-
-        // invoked by JXP
-        @SuppressWarnings("unused")
-        public WidgetActionContribution(Element element, List<XmlElement> subElements, Context context) {
-            super(element, subElements, context);
+        public WidgetActionContribution(Element element, NodeList childNodes, Context context) {
+            super(element, childNodes, context);
         }
 
         @Nullable

--- a/src/main/java/net/robinfriedli/botify/exceptions/ForbiddenCommandException.java
+++ b/src/main/java/net/robinfriedli/botify/exceptions/ForbiddenCommandException.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 
 
 /**
@@ -18,7 +18,7 @@ public class ForbiddenCommandException extends UserException {
             commandIdentifier,
             roles.isEmpty()
                 ? "Only available to guild owner and administrator roles"
-                : "Requires any of these roles: " + StringListImpl.create(roles, Role::getName).toSeparatedString(", ")));
+                : "Requires any of these roles: " + StringList.create(roles, Role::getName).toSeparatedString(", ")));
     }
 
     public ForbiddenCommandException(User user, String commandIdentifier, String availableTo) {

--- a/src/main/java/net/robinfriedli/botify/interceptors/AlertPlaylistModificationInterceptor.java
+++ b/src/main/java/net/robinfriedli/botify/interceptors/AlertPlaylistModificationInterceptor.java
@@ -11,7 +11,7 @@ import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.discord.MessageService;
 import net.robinfriedli.botify.entities.Playlist;
 import net.robinfriedli.botify.entities.PlaylistItem;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Interceptor;
 
 public class AlertPlaylistModificationInterceptor extends CollectingInterceptor {
@@ -34,12 +34,12 @@ public class AlertPlaylistModificationInterceptor extends CollectingInterceptor 
 
         if (!createdPlaylists.isEmpty()) {
             String s = createdPlaylists.size() > 1 ? "Created playlists: " : "Created playlist: ";
-            messageService.sendSuccess(s + StringListImpl.create(createdPlaylists, Playlist::getName).toSeparatedString(", "), channel);
+            messageService.sendSuccess(s + StringList.create(createdPlaylists, Playlist::getName).toSeparatedString(", "), channel);
         }
 
         if (!deletedPlaylists.isEmpty()) {
             String s = deletedPlaylists.size() > 1 ? "Deleted playlists: " : "Deleted playlist: ";
-            messageService.sendSuccess(s + StringListImpl.create(deletedPlaylists, Playlist::getName).toSeparatedString(", "), channel);
+            messageService.sendSuccess(s + StringList.create(deletedPlaylists, Playlist::getName).toSeparatedString(", "), channel);
         }
 
         if (!addedItems.isEmpty()) {

--- a/src/main/java/net/robinfriedli/botify/interceptors/AlertPresetCreationInterceptor.java
+++ b/src/main/java/net/robinfriedli/botify/interceptors/AlertPresetCreationInterceptor.java
@@ -8,7 +8,7 @@ import net.dv8tion.jda.api.entities.MessageChannel;
 import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.discord.MessageService;
 import net.robinfriedli.botify.entities.Preset;
-import net.robinfriedli.stringlist.StringListImpl;
+import net.robinfriedli.stringlist.StringList;
 import org.hibernate.Interceptor;
 
 public class AlertPresetCreationInterceptor extends CollectingInterceptor {
@@ -34,7 +34,7 @@ public class AlertPresetCreationInterceptor extends CollectingInterceptor {
                 messageService.sendSuccess("Saved preset " + createdPreset.getName(), channel);
             } else {
                 messageService.sendSuccess("Saved presets "
-                    + StringListImpl.create(createdPresets, Preset::getName).toSeparatedString(", "), channel);
+                    + StringList.create(createdPresets, Preset::getName).toSeparatedString(", "), channel);
             }
         }
 
@@ -44,7 +44,7 @@ public class AlertPresetCreationInterceptor extends CollectingInterceptor {
                 messageService.sendSuccess("Deleted preset " + deletedPreset.getName(), channel);
             } else {
                 messageService.sendSuccess("Deleted presets "
-                    + StringListImpl.create(deletedPresets, Preset::getName).toSeparatedString(", "), channel);
+                    + StringList.create(deletedPresets, Preset::getName).toSeparatedString(", "), channel);
             }
         }
     }

--- a/src/main/java/net/robinfriedli/botify/interceptors/InterceptorChain.java
+++ b/src/main/java/net/robinfriedli/botify/interceptors/InterceptorChain.java
@@ -19,6 +19,7 @@ import org.hibernate.type.Type;
  */
 public class InterceptorChain extends EmptyInterceptor {
 
+    public static ThreadLocal<Boolean> INTERCEPTORS_MUTED = ThreadLocal.withInitial(() -> false);
     private final Interceptor first;
 
     public InterceptorChain(Interceptor first) {
@@ -73,92 +74,165 @@ public class InterceptorChain extends EmptyInterceptor {
 
     @Override
     public void onDelete(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
-        first.onDelete(entity, id, state, propertyNames, types);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.onDelete(entity, id, state, propertyNames, types);
+        } else {
+            super.onDelete(entity, id, state, propertyNames, types);
+        }
     }
 
     @Override
     public boolean onFlushDirty(Object entity, Serializable id, Object[] currentState, Object[] previousState, String[] propertyNames, Type[] types) {
-        return first.onFlushDirty(entity, id, currentState, previousState, propertyNames, types);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.onFlushDirty(entity, id, currentState, previousState, propertyNames, types);
+        } else {
+            return super.onFlushDirty(entity, id, currentState, previousState, propertyNames, types);
+        }
     }
 
     @Override
     public boolean onLoad(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
-        return first.onLoad(entity, id, state, propertyNames, types);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.onLoad(entity, id, state, propertyNames, types);
+        } else {
+            return super.onLoad(entity, id, state, propertyNames, types);
+        }
     }
 
     @Override
     public boolean onSave(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
-        return first.onSave(entity, id, state, propertyNames, types);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.onSave(entity, id, state, propertyNames, types);
+        } else {
+            return super.onSave(entity, id, state, propertyNames, types);
+        }
     }
 
     @Override
     public void postFlush(Iterator entities) {
-        first.postFlush(entities);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.postFlush(entities);
+        } else {
+            super.postFlush(entities);
+        }
     }
 
     @Override
     public void preFlush(Iterator entities) {
-        first.preFlush(entities);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.preFlush(entities);
+        } else {
+            super.preFlush(entities);
+        }
     }
 
     @Override
     public Boolean isTransient(Object entity) {
-        return first.isTransient(entity);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.isTransient(entity);
+        } else {
+            return super.isTransient(entity);
+        }
     }
 
     @Override
     public Object instantiate(String entityName, EntityMode entityMode, Serializable id) {
-        return first.instantiate(entityName, entityMode, id);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.instantiate(entityName, entityMode, id);
+        } else {
+            return super.instantiate(entityName, entityMode, id);
+        }
     }
 
     @Override
     public int[] findDirty(Object entity, Serializable id, Object[] currentState, Object[] previousState, String[] propertyNames, Type[] types) {
-        return first.findDirty(entity, id, currentState, previousState, propertyNames, types);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.findDirty(entity, id, currentState, previousState, propertyNames, types);
+        } else {
+            return super.findDirty(entity, id, currentState, previousState, propertyNames, types);
+        }
     }
 
     @Override
     public String getEntityName(Object object) {
-        return first.getEntityName(object);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.getEntityName(object);
+        } else {
+            return super.getEntityName(object);
+        }
     }
 
     @Override
     public Object getEntity(String entityName, Serializable id) {
-        return first.getEntity(entityName, id);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.getEntity(entityName, id);
+        } else {
+            return super.getEntity(entityName, id);
+        }
     }
 
     @Override
     public void afterTransactionBegin(Transaction tx) {
-        first.afterTransactionBegin(tx);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.afterTransactionBegin(tx);
+        } else {
+            super.afterTransactionBegin(tx);
+        }
     }
 
     @Override
     public void afterTransactionCompletion(Transaction tx) {
-        first.afterTransactionCompletion(tx);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.afterTransactionCompletion(tx);
+        } else {
+            super.afterTransactionCompletion(tx);
+        }
     }
 
     @Override
     public void beforeTransactionCompletion(Transaction tx) {
-        first.beforeTransactionCompletion(tx);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.beforeTransactionCompletion(tx);
+        } else {
+            super.beforeTransactionCompletion(tx);
+        }
     }
 
+    @Deprecated
     @Override
     public String onPrepareStatement(String sql) {
-        return first.onPrepareStatement(sql);
+        if (!INTERCEPTORS_MUTED.get()) {
+            return first.onPrepareStatement(sql);
+        } else {
+            return super.onPrepareStatement(sql);
+        }
     }
 
     @Override
     public void onCollectionRemove(Object collection, Serializable key) throws CallbackException {
-        first.onCollectionRemove(collection, key);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.onCollectionRemove(collection, key);
+        } else {
+            super.onCollectionRemove(collection, key);
+        }
     }
 
     @Override
     public void onCollectionRecreate(Object collection, Serializable key) throws CallbackException {
-        first.onCollectionRecreate(collection, key);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.onCollectionRecreate(collection, key);
+        } else {
+            super.onCollectionRecreate(collection, key);
+        }
     }
 
     @Override
     public void onCollectionUpdate(Object collection, Serializable key) throws CallbackException {
-        first.onCollectionUpdate(collection, key);
+        if (!INTERCEPTORS_MUTED.get()) {
+            first.onCollectionUpdate(collection, key);
+        } else {
+            super.onCollectionUpdate(collection, key);
+        }
     }
 
 }

--- a/src/main/java/net/robinfriedli/botify/listeners/CommandListener.java
+++ b/src/main/java/net/robinfriedli/botify/listeners/CommandListener.java
@@ -120,7 +120,6 @@ public class CommandListener extends ListenerAdapter {
         ThreadExecutionQueue queue = executionQueueManager.getForGuild(guild);
         String commandBody = message.getContentDisplay().substring(namePrefix.length()).trim();
         CommandContext commandContext = new CommandContext(event, guildContext, sessionFactory, spotifyApiBuilder.build(), commandBody);
-        CommandContext.Current.set(commandContext);
         try {
             Optional<AbstractCommand> commandInstance = commandManager.instantiateCommandForContext(commandContext, session);
             commandInstance.ifPresent(command -> commandManager.runCommand(command, queue));

--- a/src/main/java/net/robinfriedli/botify/login/LoginManager.java
+++ b/src/main/java/net/robinfriedli/botify/login/LoginManager.java
@@ -13,8 +13,8 @@ import net.robinfriedli.botify.util.ISnowflakeMap;
  */
 public class LoginManager {
 
-    private ISnowflakeMap<Login> logins = new ISnowflakeMap<>();
-    private ISnowflakeMap<CompletableFuture<Login>> expectedLogins = new ISnowflakeMap<>();
+    private final ISnowflakeMap<Login> logins = new ISnowflakeMap<>();
+    private final ISnowflakeMap<CompletableFuture<Login>> expectedLogins = new ISnowflakeMap<>();
 
     public void addLogin(Login login) {
         logins.put(login.getUser(), login);

--- a/src/main/java/net/robinfriedli/botify/servers/HttpServerStarter.java
+++ b/src/main/java/net/robinfriedli/botify/servers/HttpServerStarter.java
@@ -34,7 +34,7 @@ public class HttpServerStarter {
         HttpServer httpServer = HttpServer.create(new InetSocketAddress(port), 0);
 
         ExecutorService executorService = new ThreadPoolExecutor(1, 5, 30, TimeUnit.SECONDS, new SynchronousQueue<>(), new ThreadFactory() {
-            AtomicLong threadId = new AtomicLong(1);
+            final AtomicLong threadId = new AtomicLong(1);
 
             @Override
             public Thread newThread(@NotNull Runnable r) {

--- a/src/main/java/net/robinfriedli/botify/util/Table.java
+++ b/src/main/java/net/robinfriedli/botify/util/Table.java
@@ -146,7 +146,7 @@ public class Table {
     public class Row {
 
         private final List<Cell> cells;
-        private boolean isOverflow;
+        private final boolean isOverflow;
         private int lines = 1;
 
         Row(List<Cell> cells) {
@@ -246,9 +246,9 @@ public class Table {
     public class Cell {
 
         private final String content;
+        private final List<String> lines;
         private Integer width;
         private boolean overflow;
-        private List<String> lines;
 
         Cell(String content) {
             this.content = content;


### PR DESCRIPTION
 - only allow one CommandContext instance to be installed for one
   thread and prohibit using #getSession from a thread different from
   the thread associated with this CommandContext
   - introduce #threadSafe to create a threadsafe copy of the
     CommandContext
 - add StaticSessionProvider#invokeWithoutInterceptors and add a thread
   local field to InterceptorChain to toggle interceptors
   - used by GuildManager#initializeGuild to disable sending a success
     message when creating an AccessConfiguration upon initializing a
     guild when using the analytics command