### PR TITLE
refactor QueueIterator and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.sedmelluq</groupId>
       <artifactId>lavaplayer</artifactId>
-      <version>1.3.47</version>
+      <version>1.3.48</version>
     </dependency>
     <dependency>
       <groupId>com.sedmelluq</groupId>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>net.dv8tion</groupId>
       <artifactId>JDA</artifactId>
-      <version>4.1.1_142</version>
+      <version>4.1.1_149</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioPlayback.java
@@ -209,7 +209,7 @@ public class AudioPlayback {
     public void setCurrentQueueIterator(QueueIterator queueIterator) {
         if (currentQueueIterator != null) {
             audioPlayer.removeListener(currentQueueIterator);
-            currentQueueIterator.setReplaced(true);
+            currentQueueIterator.setReplaced();
         }
 
         currentQueueIterator = queueIterator;

--- a/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
+++ b/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
@@ -36,11 +36,15 @@ public class QueueIterator extends AudioEventAdapter {
     private final MessageService messageService;
     private final AudioTrackLoader audioTrackLoader;
     private Playable currentlyPlaying;
-    private boolean isReplaced;
-    // incremented when a track fails to load and is automatically skipped. This exists to define a maximum number of
-    // tracks that can be auto skipped to avoid the queue hanging for too long and only send a message on the first
-    // attempt to avoid spam
-    private int retryCount;
+
+    private volatile boolean isReplaced;
+    // Incremented when attempting to play the next track and reset when a track ends successfully.
+    //
+    // For the perspective of QueueIterator instances tracks are either finished completely or fail
+    // due to an error. If the user skips a track a new QueueIterator instance is created.
+    //
+    // Value is not atomic because it is not expected to be updated concurrently but only by the audio connection thread.
+    private int attemptCount;
 
     QueueIterator(AudioPlayback playback, AudioManager audioManager) {
         this.playback = playback;
@@ -72,7 +76,10 @@ public class QueueIterator extends AudioEventAdapter {
                 // only reset the retryCount once a track has ended successfully, as tracks can fail after they started
                 // and tracks that fail immediately after they start, e.g. a soundcloud track throwing a 401, would still
                 // spam the chat
-                resetRetryCount();
+                //
+                // hint: for the perspective of QueueIterator instances tracks are either finished completely or fail
+                // due to an error. If the user skips a track a new QueueIterator instance is created
+                resetAttemptCount();
                 iterateQueue(playback, queue);
             }
         }
@@ -85,11 +92,10 @@ public class QueueIterator extends AudioEventAdapter {
             e = e.getCause();
         }
         sendError(queue.getCurrent(), e);
-        ++retryCount;
     }
 
-    void setReplaced(boolean replaced) {
-        isReplaced = replaced;
+    void setReplaced() {
+        isReplaced = true;
     }
 
     void playNext() {
@@ -98,13 +104,15 @@ public class QueueIterator extends AudioEventAdapter {
         }
 
         // don't skip over more than 10 items to avoid a frozen queue
-        if (retryCount == 10) {
+        if (++attemptCount > 10) {
             EmbedBuilder embedBuilder = new EmbedBuilder();
             embedBuilder.setColor(Color.RED);
             embedBuilder.setDescription("Queue contains too many unplayable tracks subsequently for automatic skipping. You can skip to the next valid track manually.");
             messageService.sendTemporary(embedBuilder.build(), playback.getCommunicationChannel());
             playback.stop();
-            resetRetryCount();
+            // reset just in case, even though the same QueueIterator instance will currently never be used again as the
+            // user now either has to skip manually or start a new playback, creating a new iterator
+            resetAttemptCount();
             return;
         }
 
@@ -129,7 +137,6 @@ public class QueueIterator extends AudioEventAdapter {
             } catch (FriendlyException e) {
                 sendError(track, e);
 
-                ++retryCount;
                 iterateQueue(playback, queue, true);
                 return;
             }
@@ -176,7 +183,7 @@ public class QueueIterator extends AudioEventAdapter {
     }
 
     private void sendError(Playable track, Throwable e) {
-        if (retryCount == 0) {
+        if (attemptCount == 1) {
             EmbedBuilder embedBuilder = new EmbedBuilder();
             embedBuilder.setTitle("Could not load track " + track.display());
 
@@ -246,8 +253,8 @@ public class QueueIterator extends AudioEventAdapter {
         }
     }
 
-    private void resetRetryCount() {
-        retryCount = 0;
+    private void resetAttemptCount() {
+        attemptCount = 0;
     }
 
     public Playable getCurrentlyPlaying() {


### PR DESCRIPTION
 - the retryCount of the QueueIterator was refactored to an attemptCount
   that gets incremented each time before playing the next time and only
   reset once a track finishes successfully
   - For the perspective of QueueIterator instances tracks are either
     finished completely or fail due to an error. If the user skips a
     track a new QueueIterator instance is created.
   - this ensures all cases where a track does not finish successfully
     are covered even when no track exception or end event are fired
 - lavaplayer update fixes random NullPointerExceptions when playing
   youtube content