### PR TITLE
synchronise access to SpotifyRedirectIndices of the same id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,13 @@
     </dependency>
     <dependency>
       <groupId>net.robinfriedli</groupId>
+      <artifactId>exec</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>net.robinfriedli</groupId>
       <artifactId>JXP</artifactId>
-      <version>2.0</version>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>net.robinfriedli</groupId>

--- a/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/AbstractCommand.java
@@ -35,7 +35,7 @@ import net.robinfriedli.botify.function.HibernateInvoker;
 import net.robinfriedli.botify.function.SpotifyInvoker;
 import net.robinfriedli.botify.login.Login;
 import net.robinfriedli.botify.util.Util;
-import net.robinfriedli.jxp.exec.modes.SynchronisationMode;
+import net.robinfriedli.exec.modes.SynchronisationMode;
 import net.robinfriedli.stringlist.StringList;
 
 /**

--- a/src/main/java/net/robinfriedli/botify/cron/AbstractCronTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/AbstractCronTask.java
@@ -5,8 +5,8 @@ import org.slf4j.LoggerFactory;
 
 import net.robinfriedli.botify.function.modes.HibernateTransactionMode;
 import net.robinfriedli.botify.function.modes.SpotifyAuthorizationMode;
-import net.robinfriedli.jxp.exec.BaseInvoker;
-import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.exec.Invoker;
+import net.robinfriedli.exec.Mode;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 
@@ -19,7 +19,7 @@ public abstract class AbstractCronTask implements Job {
     private final Logger logger;
 
     public AbstractCronTask() {
-        invoker = new BaseInvoker();
+        invoker = Invoker.newInstance();
         logger = LoggerFactory.getLogger(getClass());
     }
 
@@ -44,12 +44,12 @@ public abstract class AbstractCronTask implements Job {
     protected abstract void run(JobExecutionContext jobExecutionContext) throws Exception;
 
     /**
-     * The {@link Invoker.Mode} to invoke the run method with. For example, use the {@link HibernateTransactionMode}
+     * The {@link Mode} to invoke the run method with. For example, use the {@link HibernateTransactionMode}
      * if the task needs to run in a hibernate transaction, or {@link SpotifyAuthorizationMode} if the task needs to run
      * with Spotify client credentials set up.
      *
      * @return the mode to use
      */
-    protected abstract Invoker.Mode getMode();
+    protected abstract Mode getMode();
 
 }

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/ClearAbandonedGuildContextsTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/ClearAbandonedGuildContextsTask.java
@@ -10,7 +10,7 @@ import net.robinfriedli.botify.discord.CommandExecutionQueueManager;
 import net.robinfriedli.botify.discord.GuildContext;
 import net.robinfriedli.botify.discord.GuildManager;
 import net.robinfriedli.botify.listeners.GuildManagementListener;
-import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.exec.Mode;
 import org.quartz.JobExecutionContext;
 
 /**
@@ -42,7 +42,7 @@ public class ClearAbandonedGuildContextsTask extends AbstractCronTask {
     }
 
     @Override
-    protected Invoker.Mode getMode() {
-        return Invoker.Mode.create();
+    protected Mode getMode() {
+        return Mode.create();
     }
 }

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/DeleteGrantedRolesForDeletedRolesTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/DeleteGrantedRolesForDeletedRolesTask.java
@@ -17,7 +17,7 @@ import net.robinfriedli.botify.entities.GrantedRole;
 import net.robinfriedli.botify.entities.GuildSpecification;
 import net.robinfriedli.botify.function.modes.HibernateTransactionMode;
 import net.robinfriedli.botify.util.StaticSessionProvider;
-import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.exec.Mode;
 import org.quartz.JobExecutionContext;
 
 /**
@@ -63,7 +63,7 @@ public class DeleteGrantedRolesForDeletedRolesTask extends AbstractCronTask {
     }
 
     @Override
-    protected Invoker.Mode getMode() {
-        return Invoker.Mode.create().with(new HibernateTransactionMode());
+    protected Mode getMode() {
+        return Mode.create().with(new HibernateTransactionMode());
     }
 }

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/PlaybackCleanupTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/PlaybackCleanupTask.java
@@ -14,7 +14,7 @@ import net.robinfriedli.botify.cron.AbstractCronTask;
 import net.robinfriedli.botify.discord.GuildContext;
 import net.robinfriedli.botify.discord.GuildManager;
 import net.robinfriedli.botify.util.StaticSessionProvider;
-import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.exec.Mode;
 import org.quartz.JobExecutionContext;
 
 /**
@@ -65,7 +65,7 @@ public class PlaybackCleanupTask extends AbstractCronTask {
     }
 
     @Override
-    protected Invoker.Mode getMode() {
-        return Invoker.Mode.create();
+    protected Mode getMode() {
+        return Mode.create();
     }
 }

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/RefreshSpotifyRedirectIndicesTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/RefreshSpotifyRedirectIndicesTask.java
@@ -32,7 +32,7 @@ import net.robinfriedli.botify.exceptions.UnavailableResourceException;
 import net.robinfriedli.botify.function.modes.HibernateTransactionMode;
 import net.robinfriedli.botify.function.modes.SpotifyAuthorizationMode;
 import net.robinfriedli.botify.util.StaticSessionProvider;
-import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.exec.Mode;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
@@ -125,8 +125,8 @@ public class RefreshSpotifyRedirectIndicesTask extends AbstractCronTask {
     }
 
     @Override
-    protected Invoker.Mode getMode() {
-        return Invoker.Mode.create().with(new HibernateTransactionMode()).with(new SpotifyAuthorizationMode(spotifyApi));
+    protected Mode getMode() {
+        return Mode.create().with(new HibernateTransactionMode()).with(new SpotifyAuthorizationMode(spotifyApi));
     }
 
     private class RefreshTrackIndexTask implements Consumer<Track> {

--- a/src/main/java/net/robinfriedli/botify/cron/tasks/ResetCurrentYouTubeQuotaTask.java
+++ b/src/main/java/net/robinfriedli/botify/cron/tasks/ResetCurrentYouTubeQuotaTask.java
@@ -8,7 +8,7 @@ import net.robinfriedli.botify.cron.AbstractCronTask;
 import net.robinfriedli.botify.entities.CurrentYouTubeQuotaUsage;
 import net.robinfriedli.botify.function.modes.HibernateTransactionMode;
 import net.robinfriedli.botify.util.StaticSessionProvider;
-import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.exec.Mode;
 import org.quartz.JobExecutionContext;
 
 /**
@@ -28,7 +28,7 @@ public class ResetCurrentYouTubeQuotaTask extends AbstractCronTask {
     }
 
     @Override
-    protected Invoker.Mode getMode() {
-        return Invoker.Mode.create().with(new HibernateTransactionMode());
+    protected Mode getMode() {
+        return Mode.create().with(new HibernateTransactionMode());
     }
 }

--- a/src/main/java/net/robinfriedli/botify/function/HibernateInvoker.java
+++ b/src/main/java/net/robinfriedli/botify/function/HibernateInvoker.java
@@ -6,8 +6,10 @@ import javax.annotation.Nullable;
 
 import net.robinfriedli.botify.exceptions.CommandRuntimeException;
 import net.robinfriedli.botify.function.modes.HibernateTransactionMode;
-import net.robinfriedli.jxp.exec.BaseInvoker;
-import net.robinfriedli.jxp.exec.modes.SynchronisationMode;
+import net.robinfriedli.exec.BaseInvoker;
+import net.robinfriedli.exec.Mode;
+import net.robinfriedli.exec.modes.SynchronisationMode;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Invoker that runs a task in a hibernate transaction by using the {@link HibernateTransactionMode}
@@ -29,7 +31,7 @@ public class HibernateInvoker extends BaseInvoker {
     }
 
     @Override
-    public <E> E invoke(Mode mode, Callable<E> task) {
+    public <E> E invoke(@NotNull Mode mode, @NotNull Callable<E> task) {
         if (synchronisationLock != null) {
             mode.with(new SynchronisationMode(synchronisationLock));
         }

--- a/src/main/java/net/robinfriedli/botify/function/SpotifyInvoker.java
+++ b/src/main/java/net/robinfriedli/botify/function/SpotifyInvoker.java
@@ -8,7 +8,9 @@ import com.wrapper.spotify.SpotifyApi;
 import net.robinfriedli.botify.function.modes.SpotifyAuthorizationMode;
 import net.robinfriedli.botify.function.modes.SpotifyUserAuthorizationMode;
 import net.robinfriedli.botify.login.Login;
-import net.robinfriedli.jxp.exec.BaseInvoker;
+import net.robinfriedli.exec.BaseInvoker;
+import net.robinfriedli.exec.Mode;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Invoker that runs a task with the appropriate Spotify credentials -> the credentials for the provided login or, if
@@ -38,7 +40,7 @@ public class SpotifyInvoker extends BaseInvoker {
     }
 
     @Override
-    public <E> E invoke(Mode mode, Callable<E> task) throws Exception {
+    public <E> E invoke(@NotNull Mode mode, @NotNull Callable<E> task) throws Exception {
         if (login != null) {
             mode.with(new SpotifyUserAuthorizationMode(login, spotifyApi));
         } else {

--- a/src/main/java/net/robinfriedli/botify/function/modes/SpotifyAuthorizationMode.java
+++ b/src/main/java/net/robinfriedli/botify/function/modes/SpotifyAuthorizationMode.java
@@ -4,13 +4,14 @@ import java.util.concurrent.Callable;
 
 import com.wrapper.spotify.SpotifyApi;
 import com.wrapper.spotify.model_objects.credentials.ClientCredentials;
-import net.robinfriedli.jxp.exec.AbstractDelegatingModeWrapper;
-import net.robinfriedli.jxp.exec.Invoker;
+import net.robinfriedli.exec.AbstractNestedModeWrapper;
+import net.robinfriedli.exec.Mode;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Mode that runs the given task with default Spotify credentials applied
  */
-public class SpotifyAuthorizationMode extends AbstractDelegatingModeWrapper {
+public class SpotifyAuthorizationMode extends AbstractNestedModeWrapper {
 
     private final SpotifyApi spotifyApi;
 
@@ -19,7 +20,7 @@ public class SpotifyAuthorizationMode extends AbstractDelegatingModeWrapper {
     }
 
     @Override
-    public <E> Callable<E> wrap(Callable<E> callable) {
+    public <E> @NotNull Callable<E> wrap(@NotNull Callable<E> callable) {
         return () -> {
             try {
                 ClientCredentials credentials = spotifyApi.clientCredentials().build().execute();
@@ -32,8 +33,8 @@ public class SpotifyAuthorizationMode extends AbstractDelegatingModeWrapper {
         };
     }
 
-    public Invoker.Mode getMode(SpotifyApi spotifyApi) {
-        return Invoker.Mode.create().with(new SpotifyAuthorizationMode(spotifyApi));
+    public Mode getMode(SpotifyApi spotifyApi) {
+        return Mode.create().with(new SpotifyAuthorizationMode(spotifyApi));
     }
 
 }

--- a/src/main/java/net/robinfriedli/botify/function/modes/SpotifyUserAuthorizationMode.java
+++ b/src/main/java/net/robinfriedli/botify/function/modes/SpotifyUserAuthorizationMode.java
@@ -4,12 +4,13 @@ import java.util.concurrent.Callable;
 
 import com.wrapper.spotify.SpotifyApi;
 import net.robinfriedli.botify.login.Login;
-import net.robinfriedli.jxp.exec.AbstractDelegatingModeWrapper;
+import net.robinfriedli.exec.AbstractNestedModeWrapper;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Mode that runs the given task with Spotify credentials for the given Login applied applied
  */
-public class SpotifyUserAuthorizationMode extends AbstractDelegatingModeWrapper {
+public class SpotifyUserAuthorizationMode extends AbstractNestedModeWrapper {
 
     private final Login login;
     private final SpotifyApi spotifyApi;
@@ -20,7 +21,7 @@ public class SpotifyUserAuthorizationMode extends AbstractDelegatingModeWrapper 
     }
 
     @Override
-    public <E> Callable<E> wrap(Callable<E> callable) {
+    public <E> @NotNull Callable<E> wrap(@NotNull Callable<E> callable) {
         return () -> {
             try {
                 spotifyApi.setAccessToken(login.getAccessToken());


### PR DESCRIPTION
 - map a mutex to the spotify track id and use it for synchronisation
   when querying / modifying a SpotifyRedirectIndex to avoid issues with
   optimistic locking
 - add dependency for the exec library and use its MutexSync