### PR TITLE
QueueIterator: improve message output

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/Playable.java
+++ b/src/main/java/net/robinfriedli/botify/audio/Playable.java
@@ -36,11 +36,13 @@ public interface Playable {
     String getDisplay() throws UnavailableResourceException;
 
     /**
-     * @return the display of the Playable, showing cancelled Playables as "[UNAVAILABLE]"
+     * @return the display of the Playable, showing cancelled Playables as "[UNAVAILABLE]" and fall back to "[NO TITLE]"
+     * if null.
      */
     default String display() {
         try {
-            return getDisplay();
+            String display = getDisplay();
+            return display != null ? display : "[NO TITLE]";
         } catch (UnavailableResourceException e) {
             return "[UNAVAILABLE]";
         }

--- a/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
+++ b/src/main/java/net/robinfriedli/botify/audio/QueueIterator.java
@@ -91,7 +91,7 @@ public class QueueIterator extends AudioEventAdapter {
         while (e.getCause() != null) {
             e = e.getCause();
         }
-        sendError(queue.getCurrent(), e);
+        sendError(track.getUserData(Playable.class), e);
     }
 
     void setReplaced() {
@@ -145,6 +145,7 @@ public class QueueIterator extends AudioEventAdapter {
             if (result instanceof AudioTrack) {
                 AudioTrack audioTrack = (AudioTrack) result;
                 track.setCached(audioTrack);
+                audioTrack.setUserData(track);
                 playback.getAudioPlayer().playTrack(audioTrack);
                 currentlyPlaying = track;
             } else {
@@ -185,7 +186,11 @@ public class QueueIterator extends AudioEventAdapter {
     private void sendError(Playable track, Throwable e) {
         if (attemptCount == 1) {
             EmbedBuilder embedBuilder = new EmbedBuilder();
-            embedBuilder.setTitle("Could not load track " + track.display());
+            if (track != null) {
+                embedBuilder.setTitle("Could not load track " + track.display());
+            } else {
+                embedBuilder.setTitle("Could not load current track");
+            }
 
             if (e.getMessage() != null) {
                 embedBuilder.setDescription("Message returned by source: " + e.getMessage());


### PR DESCRIPTION
 - add Playable to userData of AudioTrack and retrieve the Playable that
   way for #onTrackException because using the current track of the
   queue is unreliable as onTrackEnd might have already been called by
   the JDA AudioConnection thread, causing the error message to display
   the track that is now playing rather than the track that failed to
   load
 - handle edge case where Playable#display() returns null and return
   "[NO TITLE]" instead