### PR TITLE
adjust startup process and run certain StartupTasks for each shard

### DIFF
--- a/resources/schemas/startupTaskSchema.xsd
+++ b/resources/schemas/startupTaskSchema.xsd
@@ -8,6 +8,7 @@
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="startupTask">
+    <xs:attribute name="runForEachShard" type="xs:boolean"/>
     <xs:attribute name="implementation" type="xs:string"/>
   </xs:complexType>
 

--- a/resources/xml-contributions/startupTasks.xml
+++ b/resources/xml-contributions/startupTasks.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <startupTasks xmlns="startupTaskSpace">
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.RunLiquibaseUpdateTask"/>
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.MigrateGuildSpecificationsTask"/>
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.CreatePermissionAccessConfigurationTask"/>
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.SetRedirectedSpotifyTrackNameTask"/>
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.MigratePlaylistsTask"/>
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.VersionUpdateAlertTask"/>
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.SetPlaylistItemIndexTask"/>
-  <startupTask implementation="net.robinfriedli.botify.boot.tasks.ResetOutdatedYouTubeQuotaTask"/>
+  <startupTask runForEachShard="false" implementation="net.robinfriedli.botify.boot.tasks.RunLiquibaseUpdateTask"/>
+  <startupTask runForEachShard="true" implementation="net.robinfriedli.botify.boot.tasks.MigrateGuildSpecificationsTask"/>
+  <startupTask runForEachShard="false" implementation="net.robinfriedli.botify.boot.tasks.CreatePermissionAccessConfigurationTask"/>
+  <startupTask runForEachShard="false" implementation="net.robinfriedli.botify.boot.tasks.SetRedirectedSpotifyTrackNameTask"/>
+  <startupTask runForEachShard="true" implementation="net.robinfriedli.botify.boot.tasks.MigratePlaylistsTask"/>
+  <startupTask runForEachShard="true" implementation="net.robinfriedli.botify.boot.tasks.VersionUpdateAlertTask"/>
+  <startupTask runForEachShard="false" implementation="net.robinfriedli.botify.boot.tasks.SetPlaylistItemIndexTask"/>
+  <startupTask runForEachShard="false" implementation="net.robinfriedli.botify.boot.tasks.ResetOutdatedYouTubeQuotaTask"/>
 </startupTasks>

--- a/src/main/java/net/robinfriedli/botify/boot/StartupTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/StartupTask.java
@@ -1,5 +1,10 @@
 package net.robinfriedli.botify.boot;
 
+import javax.annotation.Nullable;
+
+import net.dv8tion.jda.api.JDA;
+import net.robinfriedli.botify.entities.xml.StartupTaskContribution;
+
 /**
  * Interface for tasks that migrate data for updates or ensure the integrity of the database
  */
@@ -7,7 +12,18 @@ public interface StartupTask {
 
     /**
      * The task to run.
+     *
+     * @param shard the shard this task is executed for, null if runForEachShard is false
      */
-    void perform() throws Exception;
+    void perform(@Nullable JDA shard) throws Exception;
+
+    default void runTask(@Nullable JDA shard) throws Exception {
+        if (shard == null && getContribution().getAttribute("runForEachShard").getBool()) {
+            throw new IllegalStateException("Shard is null despite startupTask being marked runForEachShard");
+        }
+        perform(shard);
+    }
+
+    StartupTaskContribution getContribution();
 
 }

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/CreatePermissionAccessConfigurationTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/CreatePermissionAccessConfigurationTask.java
@@ -2,9 +2,13 @@ package net.robinfriedli.botify.boot.tasks;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
+import net.dv8tion.jda.api.JDA;
 import net.robinfriedli.botify.boot.StartupTask;
 import net.robinfriedli.botify.entities.AccessConfiguration;
 import net.robinfriedli.botify.entities.GuildSpecification;
+import net.robinfriedli.botify.entities.xml.StartupTaskContribution;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
@@ -14,13 +18,15 @@ import org.hibernate.SessionFactory;
 public class CreatePermissionAccessConfigurationTask implements StartupTask {
 
     private final SessionFactory sessionFactory;
+    private final StartupTaskContribution contribution;
 
-    public CreatePermissionAccessConfigurationTask(SessionFactory sessionFactory) {
+    public CreatePermissionAccessConfigurationTask(SessionFactory sessionFactory, StartupTaskContribution contribution) {
         this.sessionFactory = sessionFactory;
+        this.contribution = contribution;
     }
 
     @Override
-    public void perform() {
+    public void perform(@Nullable JDA shard) {
         try (Session session = sessionFactory.openSession()) {
             // find all guild specifications where no access configuration for the permission command exists
             List<GuildSpecification> guildSpecifications = session.createQuery("from " + GuildSpecification.class.getName()
@@ -38,5 +44,10 @@ public class CreatePermissionAccessConfigurationTask implements StartupTask {
                 session.getTransaction().commit();
             }
         }
+    }
+
+    @Override
+    public StartupTaskContribution getContribution() {
+        return contribution;
     }
 }

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/MigrateGuildSpecificationsTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/MigrateGuildSpecificationsTask.java
@@ -6,15 +6,18 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Splitter;
 import com.google.common.io.Files;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.sharding.ShardManager;
 import net.robinfriedli.botify.boot.StartupTask;
 import net.robinfriedli.botify.entities.AccessConfiguration;
 import net.robinfriedli.botify.entities.GrantedRole;
 import net.robinfriedli.botify.entities.GuildSpecification;
+import net.robinfriedli.botify.entities.xml.StartupTaskContribution;
 import net.robinfriedli.botify.util.PropertiesLoadingService;
 import net.robinfriedli.jxp.api.JxpBackend;
 import net.robinfriedli.jxp.api.XmlElement;
@@ -29,35 +32,40 @@ import static net.robinfriedli.jxp.queries.Conditions.*;
  */
 public class MigrateGuildSpecificationsTask implements StartupTask {
 
-    private final ShardManager shardManager;
     private final JxpBackend jxpBackend;
     private final SessionFactory sessionFactory;
+    private final StartupTaskContribution contribution;
 
     private final Splitter splitter = Splitter.on(",").trimResults().omitEmptyStrings();
 
-    public MigrateGuildSpecificationsTask(ShardManager shardManager, JxpBackend jxpBackend, SessionFactory sessionFactory) {
-        this.shardManager = shardManager;
+    public MigrateGuildSpecificationsTask(JxpBackend jxpBackend, SessionFactory sessionFactory, StartupTaskContribution contribution) {
         this.jxpBackend = jxpBackend;
         this.sessionFactory = sessionFactory;
+        this.contribution = contribution;
     }
 
     @Override
-    public void perform() throws IOException {
+    public StartupTaskContribution getContribution() {
+        return contribution;
+    }
+
+    @Override
+    public void perform(@Nullable JDA shard) throws IOException {
         try (Session session = sessionFactory.openSession()) {
             session.beginTransaction();
             File file = new File(PropertiesLoadingService.requireProperty("GUILD_SPECIFICATION_PATH"));
             if (file.exists()) {
-                migrateSpecifications(file, session);
+                migrateSpecifications(shard, file, session);
             }
             session.getTransaction().commit();
         }
     }
 
-    private void migrateSpecifications(File file, Session session) throws IOException {
+    private void migrateSpecifications(JDA shard, File file, Session session) throws IOException {
         try (Context context = jxpBackend.getContext(file)) {
             List<XmlElement> guildSpecifications = context.query(tagName("guildSpecification")).collect();
             for (XmlElement guildSpecification : guildSpecifications) {
-                migrateSpecification(guildSpecification, session);
+                migrateSpecification(shard, guildSpecification, session);
             }
         }
 
@@ -69,10 +77,10 @@ public class MigrateGuildSpecificationsTask implements StartupTask {
         Files.move(file, new File(directory.getPath() + "/" + file.getName()));
     }
 
-    private void migrateSpecification(XmlElement specification, Session session) {
+    private void migrateSpecification(JDA shard, XmlElement specification, Session session) {
         String guildId = specification.getAttribute("guildId").getValue();
 
-        Guild guild = shardManager.getGuildById(guildId);
+        Guild guild = shard.getGuildById(guildId);
 
         if (guild != null) {
             Optional<GuildSpecification> existingGuildSpecification = session.createQuery("from " + GuildSpecification.class.getName() +

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/ResetOutdatedYouTubeQuotaTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/ResetOutdatedYouTubeQuotaTask.java
@@ -6,9 +6,13 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import javax.annotation.Nullable;
+
+import net.dv8tion.jda.api.JDA;
 import net.robinfriedli.botify.audio.youtube.YouTubeService;
 import net.robinfriedli.botify.boot.StartupTask;
 import net.robinfriedli.botify.entities.CurrentYouTubeQuotaUsage;
+import net.robinfriedli.botify.entities.xml.StartupTaskContribution;
 import net.robinfriedli.botify.util.StaticSessionProvider;
 
 /**
@@ -16,14 +20,21 @@ import net.robinfriedli.botify.util.StaticSessionProvider;
  */
 public class ResetOutdatedYouTubeQuotaTask implements StartupTask {
 
+    private final StartupTaskContribution contribution;
     private final YouTubeService youTubeService;
 
-    public ResetOutdatedYouTubeQuotaTask(YouTubeService youTubeService) {
+    public ResetOutdatedYouTubeQuotaTask(StartupTaskContribution contribution, YouTubeService youTubeService) {
+        this.contribution = contribution;
         this.youTubeService = youTubeService;
     }
 
     @Override
-    public void perform() {
+    public StartupTaskContribution getContribution() {
+        return contribution;
+    }
+
+    @Override
+    public void perform(@Nullable JDA shard) {
         StaticSessionProvider.invokeWithSession(session -> {
             CurrentYouTubeQuotaUsage currentQuotaUsage = YouTubeService.getCurrentQuotaUsage(session);
             LocalDateTime lastUpdatedNoZone = currentQuotaUsage.getLastUpdated();

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/RunLiquibaseUpdateTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/RunLiquibaseUpdateTask.java
@@ -1,5 +1,7 @@
 package net.robinfriedli.botify.boot.tasks;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,7 +11,9 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.FileSystemResourceAccessor;
+import net.dv8tion.jda.api.JDA;
 import net.robinfriedli.botify.boot.StartupTask;
+import net.robinfriedli.botify.entities.xml.StartupTaskContribution;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
@@ -25,14 +29,16 @@ public class RunLiquibaseUpdateTask implements StartupTask {
 
     private final Logger logger;
     private final SessionFactory sessionFactory;
+    private final StartupTaskContribution contribution;
 
-    public RunLiquibaseUpdateTask(SessionFactory sessionFactory) {
+    public RunLiquibaseUpdateTask(SessionFactory sessionFactory, StartupTaskContribution contribution) {
+        this.contribution = contribution;
         logger = LoggerFactory.getLogger(getClass());
         this.sessionFactory = sessionFactory;
     }
 
     @Override
-    public void perform() {
+    public void perform(@Nullable JDA shard) {
         logger.info("Beginning liquibase update");
         try (Session session = sessionFactory.openSession()) {
             session.doWork(connection -> {
@@ -51,4 +57,8 @@ public class RunLiquibaseUpdateTask implements StartupTask {
         logger.info("Liquibase update done");
     }
 
+    @Override
+    public StartupTaskContribution getContribution() {
+        return contribution;
+    }
 }

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/SetPlaylistItemIndexTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/SetPlaylistItemIndexTask.java
@@ -2,11 +2,15 @@ package net.robinfriedli.botify.boot.tasks;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
+import net.dv8tion.jda.api.JDA;
 import net.robinfriedli.botify.boot.StartupTask;
 import net.robinfriedli.botify.entities.Playlist;
 import net.robinfriedli.botify.entities.Song;
 import net.robinfriedli.botify.entities.UrlTrack;
 import net.robinfriedli.botify.entities.Video;
+import net.robinfriedli.botify.entities.xml.StartupTaskContribution;
 import net.robinfriedli.botify.tasks.UpdatePlaylistItemIndicesTask;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -18,13 +22,20 @@ import org.hibernate.query.Query;
 public class SetPlaylistItemIndexTask implements StartupTask {
 
     private final SessionFactory sessionFactory;
+    private final StartupTaskContribution contribution;
 
-    public SetPlaylistItemIndexTask(SessionFactory sessionFactory) {
+    public SetPlaylistItemIndexTask(SessionFactory sessionFactory, StartupTaskContribution contribution) {
         this.sessionFactory = sessionFactory;
+        this.contribution = contribution;
     }
 
     @Override
-    public void perform() {
+    public StartupTaskContribution getContribution() {
+        return contribution;
+    }
+
+    @Override
+    public void perform(@Nullable JDA shard) {
         try (Session session = sessionFactory.openSession()) {
             Query<Playlist> relevantPlaylistQuery = session.createQuery("from " + Playlist.class.getName() + " as p where " +
                 "exists(from " + Song.class.getName() + " where item_index = null and playlist_pk = p.pk) or " +

--- a/src/main/java/net/robinfriedli/botify/boot/tasks/VersionUpdateAlertTask.java
+++ b/src/main/java/net/robinfriedli/botify/boot/tasks/VersionUpdateAlertTask.java
@@ -2,15 +2,18 @@ package net.robinfriedli.botify.boot.tasks;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.sharding.ShardManager;
 import net.robinfriedli.botify.boot.StartupTask;
 import net.robinfriedli.botify.boot.VersionManager;
 import net.robinfriedli.botify.discord.MessageService;
+import net.robinfriedli.botify.entities.xml.StartupTaskContribution;
 import net.robinfriedli.botify.entities.xml.Version;
 import net.robinfriedli.botify.function.CheckedConsumer;
 import net.robinfriedli.botify.util.StaticSessionProvider;
@@ -27,25 +30,35 @@ import static net.robinfriedli.jxp.queries.Conditions.*;
  */
 public class VersionUpdateAlertTask implements StartupTask {
 
-    private final ShardManager shardManager;
+    // since the task is run for each shard separately and the launched flag gets set to true the first time,
+    // this flag is used to remember whether there has been an update
+    private static boolean UPDATED = false;
+
     private final MessageService messageService;
+    private final StartupTaskContribution contribution;
     private final VersionManager versionManager;
 
-    public VersionUpdateAlertTask(ShardManager shardManager, MessageService messageService, VersionManager versionManager) {
-        this.shardManager = shardManager;
+    public VersionUpdateAlertTask(MessageService messageService, StartupTaskContribution contribution, VersionManager versionManager) {
         this.messageService = messageService;
+        this.contribution = contribution;
         this.versionManager = versionManager;
     }
 
     @Override
-    public void perform() {
+    public StartupTaskContribution getContribution() {
+        return contribution;
+    }
+
+    @Override
+    public void perform(@Nullable JDA shard) {
         Logger logger = LoggerFactory.getLogger(getClass());
         Version versionElem = versionManager.getCurrentVersion();
         if (versionElem != null) {
             Context context = versionManager.getContext();
-            if (!versionElem.getAttribute("launched").getBool()) {
+            if (UPDATED || !versionElem.getAttribute("launched").getBool()) {
+                UPDATED = true;
                 if (!(versionElem.hasAttribute("silent") && versionElem.getAttribute("silent").getBool())) {
-                    sendUpdateAlert(context, versionElem);
+                    sendUpdateAlert(context, versionElem, shard);
                 }
 
                 context.invoke(() -> versionElem.setAttribute("launched", true));
@@ -55,7 +68,7 @@ public class VersionUpdateAlertTask implements StartupTask {
         }
     }
 
-    private void sendUpdateAlert(Context context, Version versionElem) {
+    private void sendUpdateAlert(Context context, Version versionElem, JDA shard) {
         List<XmlElement> lowerLaunchedVersions = context.query(and(
             tagName("version"),
             attribute("launched").is(true),
@@ -78,7 +91,7 @@ public class VersionUpdateAlertTask implements StartupTask {
 
             // setup current thread session and handle all guilds within one session instead of opening a new session for each
             StaticSessionProvider.invokeWithSession((CheckedConsumer<Session>) session -> {
-                for (Guild guild : shardManager.getGuilds()) {
+                for (Guild guild : shard.getGuilds()) {
                     messageService.sendWithLogo(embedBuilder, guild);
                 }
             });


### PR DESCRIPTION
 - add runForEachShard flag to StartupTask contributions to run them
   for each shard when it becomes ready and provide them the shard
   - this is used for any StartupTask that requires JDA entities to be
     ready
 - add StartupListener to Launcher to setup guilds of shards as they
   become ready and run all StartupTasks where runForEachShard is true
 - SetRedirectedSpotifyTrackNameTask: remove outdated functionality that
   handles xml playlist files per guild as that would require running
   the task for each shard to keep supporting