### PR TITLE
improve HttpHandlers

### DIFF
--- a/resources/bash/launch.sh
+++ b/resources/bash/launch.sh
@@ -1,1 +1,1 @@
-mvn exec:java -Dexec.mainClass=net.robinfriedli.botify.boot.Launcher
+mvn exec:java -Dexec.mainClass=net.robinfriedli.botify.boot.Launcher -Dsun.net.httpserver.maxReqTime=30 -Dsun.net.httpserver.maxRspTime=30

--- a/src/main/java/net/robinfriedli/botify/servers/ResourceHandler.java
+++ b/src/main/java/net/robinfriedli/botify/servers/ResourceHandler.java
@@ -5,6 +5,8 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.slf4j.LoggerFactory;
+
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
@@ -15,10 +17,19 @@ public class ResourceHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        byte[] bytes = Files.readAllBytes(Path.of("." + exchange.getRequestURI().toString()));
-        exchange.sendResponseHeaders(200, bytes.length);
-        OutputStream responseBody = exchange.getResponseBody();
-        responseBody.write(bytes);
-        responseBody.close();
+        try {
+            byte[] bytes = Files.readAllBytes(Path.of("." + exchange.getRequestURI().toString()));
+            exchange.sendResponseHeaders(200, bytes.length);
+            OutputStream responseBody = exchange.getResponseBody();
+            responseBody.write(bytes);
+            responseBody.close();
+        } catch (Throwable e) {
+            String response = e.toString();
+            exchange.sendResponseHeaders(500, response.getBytes().length);
+            OutputStream responseBody = exchange.getResponseBody();
+            responseBody.write(response.getBytes());
+            responseBody.close();
+            LoggerFactory.getLogger(getClass()).error("Error in HttpHandler", e);
+        }
     }
 }

--- a/src/main/java/net/robinfriedli/botify/servers/ServerUtil.java
+++ b/src/main/java/net/robinfriedli/botify/servers/ServerUtil.java
@@ -21,7 +21,7 @@ public class ServerUtil {
         String errorPagePath = PropertiesLoadingService.requireProperty("ERROR_PAGE_PATH");
         String html = Files.readString(Path.of(errorPagePath));
         String response = String.format(html, e.getMessage());
-        exchange.sendResponseHeaders(200, response.getBytes().length);
+        exchange.sendResponseHeaders(500, response.getBytes().length);
         OutputStream responseBody = exchange.getResponseBody();
         responseBody.write(response.getBytes());
         responseBody.close();


### PR DESCRIPTION
 - set the sun.net.httpserver.maxReqTime and
   sun.net.httpserver.maxRspTime system properties in the launch script
   to stop hanging requests that were not closed properly
 - handle exceptions thrown by the ResourceHandler
 - ServerUtil: set 500 response code for exceptions