### PR TITLE
improve SpotifyRedirectService

### DIFF
--- a/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndex.java
+++ b/src/main/java/net/robinfriedli/botify/entities/SpotifyRedirectIndex.java
@@ -15,6 +15,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
 import com.google.common.base.Strings;
+import org.hibernate.FlushMode;
 import org.hibernate.Session;
 
 /**
@@ -57,7 +58,7 @@ public class SpotifyRedirectIndex implements Serializable {
         CriteriaQuery<SpotifyRedirectIndex> query = cb.createQuery(SpotifyRedirectIndex.class);
         Root<SpotifyRedirectIndex> root = query.from(SpotifyRedirectIndex.class);
         query.where(cb.equal(root.get("spotifyId"), spotifyTrackId));
-        return session.createQuery(query).uniqueResultOptional();
+        return session.createQuery(query).setHibernateFlushMode(FlushMode.MANUAL).uniqueResultOptional();
     }
 
     public long getPk() {


### PR DESCRIPTION
 - do not flush when querying SpotifyRedirectIndex by applying flush
   mode MANUAL to the query
   - flush causes optimistic locking issues with tasks that update
     SpotifyRedirectIndices in the background and stale results are not
     important because the relevant data (spotify and youtube id) does
     not usually change
 - reload SpotifyRedirectIndex in other thread instead of updating or
   merging since the state of the detached instance is stale and the
   persistent state is to be preferred
 - remove synchronisation as it was an inferior solution for what is now
   solved by changing the flush mode and reloading the entity
   - when loading multiple spotify tracks they are all redirected within
     one transaction so synchronising individual queries with the update
     tasks did not help when the ongoing transaction flushed changes of
     an update task when querying indices and the flushed tasks provoke
     an optimistic locking exception as not the entire transaction is
     synchronised