### PR TITLE
MessageService: prevent recursion when sending permission error message

### DIFF
--- a/src/main/java/net/robinfriedli/botify/function/modes/RecursionPreventionMode.java
+++ b/src/main/java/net/robinfriedli/botify/function/modes/RecursionPreventionMode.java
@@ -1,0 +1,33 @@
+package net.robinfriedli.botify.function.modes;
+
+import java.util.concurrent.Callable;
+
+import net.robinfriedli.exec.AbstractNestedModeWrapper;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Mode that breaks recursion by simply not executing tasks with this mode applied if there already is a task with this
+ * mode running in the current thread.
+ */
+public class RecursionPreventionMode extends AbstractNestedModeWrapper {
+
+    private static final ThreadLocal<Boolean> IS_RUNNING = ThreadLocal.withInitial(() -> false);
+
+    @NotNull
+    @Override
+    public <T> Callable<T> wrap(@NotNull Callable<T> callable) {
+        return () -> {
+            if (IS_RUNNING.get()) {
+                // task was already running in this mode, this is a recursive call -> return
+                return null;
+            }
+
+            IS_RUNNING.set(true);
+            try {
+                return callable.call();
+            } finally {
+                IS_RUNNING.set(false);
+            }
+        };
+    }
+}


### PR DESCRIPTION
 - sending an error message about missing permissions could lead to a
   stack overflow if that message again fails to send due to permissions
   - the MessageService does check permissions using TextChannel#canTalk
     before sending the error message, however this method does not
     cover all cases, for example if the bot lost the VIEW_CHANNEL
     permission
 - added RecursionPreventionMode to simply prevent executing tasks with
   this mode applied if there already is a task with this mode running
   in the current thread
 - send missing permission message as temporary message
 - add missing methods to send temporary messages to a guild rather than
   specific MessageChannel