### PR TITLE
MessageService: prevent recursion when sending permission error message

### DIFF
--- a/src/main/java/net/robinfriedli/botify/discord/MessageService.java
+++ b/src/main/java/net/robinfriedli/botify/discord/MessageService.java
@@ -272,8 +272,14 @@ public class MessageService {
                 logger.warn(errorMessage.toString());
 
                 futureMessage.completeExceptionally(e);
-                String message = "Bot is missing permission: " + permission.getName();
-                send(message, channel);
+
+                if (permission != Permission.VIEW_CHANNEL) {
+                    String message = "Bot is missing permission: " + permission.getName();
+
+                    RECURSION_PREVENTION_INVOKER.invoke(RECURSION_PREVENTION_MODE, () -> {
+                        send(message, channel);
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
  - sending an error message about missing permissions could lead to a
    stack overflow if that message again fails to send due to
    permissions
  - do not even attempt to send message if the missing permission is
    VIEW_CHANNEL