### PR TITLE
trim long titles when displaying the queue

### DIFF
--- a/src/main/java/net/robinfriedli/botify/audio/AudioQueue.java
+++ b/src/main/java/net/robinfriedli/botify/audio/AudioQueue.java
@@ -161,11 +161,10 @@ public class AudioQueue {
             StringBuilder nextBuilder = new StringBuilder();
 
             if (position > 0) {
-                List<Playable> previous;
                 if (position > 5) {
                     prevBuilder.append("...").append(System.lineSeparator());
                 }
-                previous = listPrevious(5);
+                List<Playable> previous = listPrevious(5);
                 for (Playable prev : previous) {
                     appendPlayable(prevBuilder, prev);
                 }
@@ -185,8 +184,7 @@ public class AudioQueue {
             );
 
             if (position < tracks.size() - 1) {
-                List<Playable> next;
-                next = listNext(5);
+                List<Playable> next = listNext(5);
                 for (Playable n : next) {
                     appendPlayable(nextBuilder, n);
                 }
@@ -437,6 +435,11 @@ public class AudioQueue {
     private void appendPlayable(StringBuilder trackListBuilder, Playable playable) {
         String display = playable.display();
         long durationMs = playable.durationMs();
+
+        if (display.length() > 100) {
+            display = display.substring(0, 95) + "[...]";
+        }
+
         trackListBuilder.append("| ").append(display).append(" - ").append(Util.normalizeMillis(durationMs)).append(System.lineSeparator());
     }
 


### PR DESCRIPTION
 - limit playable display length to 100 and trim the display to the
   first 95 chars and append "[...]" if the display exceeds that length