### PR TITLE
reorder maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,12 +211,12 @@
       <url>https://raw.github.com/robinfriedli/JXP/repository/</url>
     </repository>
     <repository>
-      <id>central</id>
-      <url>http://central.maven.org/maven2/</url>
-    </repository>
-    <repository>
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
+    </repository>
+    <repository>
+      <id>central</id>
+      <url>http://central.maven.org/maven2/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
 - move jitpack above maven central
   - maven downloads a corrupted jar from central for DBL-Java-Library
     for some users