### PR TITLE
Song: disable eager fetching for the artist collection

### DIFF
--- a/src/main/java/net/robinfriedli/botify/entities/Song.java
+++ b/src/main/java/net/robinfriedli/botify/entities/Song.java
@@ -35,7 +35,7 @@ public class Song extends PlaylistItem {
     private String id;
     @Column(name = "name")
     private String name;
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany
     private Set<Artist> artists = Sets.newHashSet();
 
     public Song() {

--- a/src/main/java/net/robinfriedli/botify/interceptors/AlertPlaylistModificationInterceptor.java
+++ b/src/main/java/net/robinfriedli/botify/interceptors/AlertPlaylistModificationInterceptor.java
@@ -1,5 +1,6 @@
 package net.robinfriedli.botify.interceptors;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -11,8 +12,11 @@ import net.robinfriedli.botify.command.CommandContext;
 import net.robinfriedli.botify.discord.MessageService;
 import net.robinfriedli.botify.entities.Playlist;
 import net.robinfriedli.botify.entities.PlaylistItem;
+import net.robinfriedli.botify.entities.Song;
 import net.robinfriedli.stringlist.StringList;
+import org.hibernate.Hibernate;
 import org.hibernate.Interceptor;
+import org.hibernate.type.Type;
 
 public class AlertPlaylistModificationInterceptor extends CollectingInterceptor {
 
@@ -23,6 +27,16 @@ public class AlertPlaylistModificationInterceptor extends CollectingInterceptor 
         super(next, logger);
         channel = commandContext.getChannel();
         this.messageService = messageService;
+    }
+
+    @Override
+    public void onDeleteChained(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
+        super.onDeleteChained(entity, id, state, propertyNames, types);
+        if (entity instanceof Song) {
+            // make sure artist collection is initialised before deletion since it might be required to display the removed
+            // song at which point the collection can not be initialised anymore
+            Hibernate.initialize(((Song) entity).getArtists());
+        }
     }
 
     @Override


### PR DESCRIPTION
 - eager fetching this collection has a large performance impact when
   loading playlists and is no longer required as the lazy
   initialisation should succeed since the session management was
   improved
 - make sure the collection is initialized before deletion
   - the artist collection is required to display the Song when removing
     a single song from a playlist but if the proxy has not been
     initialised before alerting the deletion in
     afterTransactionCompletion the proxy cannot be lazy initialised
     anymore
     - make sure the collection is initialised upon deletion by calling
       Hibernate#initialize explicitly on deletion of the Song