### PR TITLE
AlertPlaylistModificationInterceptor: only initialise artists if needed

### DIFF
--- a/src/main/java/net/robinfriedli/botify/interceptors/AlertPlaylistModificationInterceptor.java
+++ b/src/main/java/net/robinfriedli/botify/interceptors/AlertPlaylistModificationInterceptor.java
@@ -23,6 +23,8 @@ public class AlertPlaylistModificationInterceptor extends CollectingInterceptor 
     private final MessageChannel channel;
     private final MessageService messageService;
 
+    private boolean isFirstItemRemoval = true;
+
     public AlertPlaylistModificationInterceptor(Interceptor next, Logger logger, CommandContext commandContext, MessageService messageService) {
         super(next, logger);
         channel = commandContext.getChannel();
@@ -32,10 +34,15 @@ public class AlertPlaylistModificationInterceptor extends CollectingInterceptor 
     @Override
     public void onDeleteChained(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types) {
         super.onDeleteChained(entity, id, state, propertyNames, types);
-        if (entity instanceof Song) {
+        if (isFirstItemRemoval && entity instanceof Song) {
             // make sure artist collection is initialised before deletion since it might be required to display the removed
-            // song at which point the collection can not be initialised anymore
+            // song at which point the collection can not be initialised anymore, this is only required if only one item
+            // is removed, else the number of removed items is shown
             Hibernate.initialize(((Song) entity).getArtists());
+        }
+
+        if (entity instanceof PlaylistItem) {
+            isFirstItemRemoval = false;
         }
     }
 
@@ -94,4 +101,11 @@ public class AlertPlaylistModificationInterceptor extends CollectingInterceptor 
             }
         }
     }
+
+    @Override
+    protected void clearState() {
+        super.clearState();
+        isFirstItemRemoval = true;
+    }
+
 }

--- a/src/main/java/net/robinfriedli/botify/interceptors/CollectingInterceptor.java
+++ b/src/main/java/net/robinfriedli/botify/interceptors/CollectingInterceptor.java
@@ -45,12 +45,13 @@ public abstract class CollectingInterceptor extends ChainableInterceptor {
 
     @Override
     public void afterTransactionCompletionChained(Transaction tx) throws Exception {
-        if (!tx.getRollbackOnly()) {
-            afterCommit();
+        try {
+            if (!tx.getRollbackOnly()) {
+                afterCommit();
+            }
+        } finally {
+            clearState();
         }
-        createdEntities.clear();
-        deletedEntities.clear();
-        updatedEntities.clear();
     }
 
     public List<Object> getCreatedEntities() {
@@ -90,6 +91,12 @@ public abstract class CollectingInterceptor extends ChainableInterceptor {
             .filter(type::isInstance)
             .map(type::cast)
             .collect(Collectors.toList());
+    }
+
+    protected void clearState() {
+        createdEntities.clear();
+        deletedEntities.clear();
+        updatedEntities.clear();
     }
 
 }


### PR DESCRIPTION
 - only initialise the artist collection for Songs if it's the first
   item that is removed since it is only needed to display the song for
   the success message which is only done if only one item was removed,
   else the number of removed items is shown