### PR TITLE
use jda-nas as audioSendFactory if supported by current platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
     <dependency>
       <groupId>com.sedmelluq</groupId>
+      <artifactId>jda-nas</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sedmelluq</groupId>
       <artifactId>lavaplayer</artifactId>
       <version>1.3.66</version>
     </dependency>


### PR DESCRIPTION
 - jda-nas uses native code to buffer and stream audio meaning the audio
   stream in unaffected by gc activity