### PR TITLE
refactor QueueCommand#listQueue

### DIFF
--- a/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/QueueCommand.java
@@ -49,7 +49,7 @@ public class QueueCommand extends AbstractQueueLoadingCommand {
         playback.getAudioQueue().add(playables);
     }
 
-    private void listQueue() throws Exception {
+    private void listQueue() {
         Guild guild = getContext().getGuild();
         AudioManager audioManager = Botify.get().getAudioManager();
         AudioPlayback playback = audioManager.getPlaybackForGuild(guild);
@@ -57,7 +57,7 @@ public class QueueCommand extends AbstractQueueLoadingCommand {
 
         CompletableFuture<Message> futureMessage = sendMessage(audioQueue.buildMessageEmbed(playback, guild));
         WidgetManager widgetManager = getContext().getGuildContext().getWidgetManager();
-        widgetManager.registerWidget(new QueueWidget(widgetManager, futureMessage.get(), playback));
+        futureMessage.thenAccept(message -> widgetManager.registerWidget(new QueueWidget(widgetManager, message, playback)));
     }
 
     @Override


### PR DESCRIPTION
 - instead of awaiting the future message, setup the widget in the
   thenAccept callback, this also has the benefit that it does not throw
   if sending the message failed