### PR TITLE
handle audio event in separate thread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
       <version>1.6</version>
     </dependency>
     <dependency>
+      <groupId>net.robinfriedli</groupId>
+      <artifactId>ThreadPool</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
       <version>1.4.0</version>


### PR DESCRIPTION
 - when using jda-nas all audio events are handled by the same thread
   that populates the native buffer, meaning when one playback finishes
   a track and loads the next track it blocks populating the native
   buffer for all playbacks
   - this is not an issue without jda-nas because in that case the
     events are handled by the audio connection thread of the specific
     guild