### PR TITLE
PermissionCommand: avoid concurrent modification of roles when locking

### DIFF
--- a/src/main/java/net/robinfriedli/botify/command/commands/PermissionCommand.java
+++ b/src/main/java/net/robinfriedli/botify/command/commands/PermissionCommand.java
@@ -204,7 +204,7 @@ public class PermissionCommand extends AbstractCommand {
                 Optional<AccessConfiguration> existingAccessConfiguration = specification.getAccessConfiguration(selectedCommand.getIdentifier());
                 if (existingAccessConfiguration.isPresent()) {
                     AccessConfiguration accessConfiguration = existingAccessConfiguration.get();
-                    Set<GrantedRole> setRoles = accessConfiguration.getRoles();
+                    Set<GrantedRole> setRoles = Sets.newHashSet(accessConfiguration.getRoles());
                     for (GrantedRole setRole : setRoles) {
                         accessConfiguration.removeRole(setRole);
                         session.delete(setRole);


### PR DESCRIPTION
 - if an AccessConfiguration had several GrantedRoles, locking the
   command would throw a ConcurrentModificationException since roles are
   removed while iterating