### PR TITLE
add timeout for message actions to MessageService

### DIFF
--- a/src/main/java/net/robinfriedli/botify/discord/MessageService.java
+++ b/src/main/java/net/robinfriedli/botify/discord/MessageService.java
@@ -322,7 +322,7 @@ public class MessageService {
             }
 
             MessageAction messageAction = function.apply(channel);
-            messageAction.queue(futureMessage::complete, e -> {
+            messageAction.timeout(10, TimeUnit.SECONDS).queue(futureMessage::complete, e -> {
                 handleError(e, channel);
                 futureMessage.completeExceptionally(e);
             });


### PR DESCRIPTION
 - prevents queued up messages from flooding when a rate limit is lifted
   resulting in another rate limit